### PR TITLE
docs: add currency + region detail endpoints and per-tier field availability

### DIFF
--- a/api/endpoints/get-all-countries.mdx
+++ b/api/endpoints/get-all-countries.mdx
@@ -57,6 +57,36 @@ Retrieve a complete list of all countries with basic information including ISO c
   Flag emoji representation
 </ResponseField>
 
+<ResponseField name="latitude" type="string">
+  Country's approximate latitude
+</ResponseField>
+
+<ResponseField name="longitude" type="string">
+  Country's approximate longitude
+</ResponseField>
+
+<ResponseField name="region" type="string">
+  Geographic region name (e.g., Asia, Europe)
+</ResponseField>
+
+<ResponseField name="region_id" type="integer">
+  Geographic region ID (foreign key into `/regions`)
+</ResponseField>
+
+<ResponseField name="subregion" type="string">
+  Geographic subregion name (e.g., Southern Asia)
+</ResponseField>
+
+<ResponseField name="subregion_id" type="integer">
+  Geographic subregion ID (foreign key into `/subregions`)
+</ResponseField>
+
+<ResponseField name="timezones" type="string">
+  JSON string of timezones (array of `{zoneName, gmtOffset, gmtOffsetName, abbreviation, tzName}`)
+</ResponseField>
+
+<Info>Additional fields like `numeric_code`, `currency_name`, `currency_symbol`, `tld`, `nationality`, `population`, `gdp`, `area_sq_km`, `postal_code_format`, `postal_code_regex`, `emojiU`, `translations`, and `wikiDataId` are returned on higher tiers. See the **Tier-Based Field Availability** section below.</Info>
+
 <RequestExample>
 ```bash cURL
 curl -X GET 'https://api.countrystatecity.in/v1/countries' \
@@ -172,7 +202,7 @@ puts JSON.pretty_generate(countries)
 </RequestExample>
 
 <ResponseExample>
-```json 200 - Success
+```json 200 - Basic tier (Community, Starter, Legacy)
 [
   {
     "id": 101,
@@ -183,18 +213,47 @@ puts JSON.pretty_generate(countries)
     "capital": "New Delhi",
     "currency": "INR",
     "native": "भारत",
-    "emoji": "🇮🇳"
-  },
+    "emoji": "🇮🇳",
+    "latitude": "20.00000000",
+    "longitude": "77.00000000",
+    "region": "Asia",
+    "region_id": 3,
+    "subregion": "Southern Asia",
+    "subregion_id": 14,
+    "timezones": "[{\"zoneName\":\"Asia/Kolkata\",\"gmtOffset\":19800,\"gmtOffsetName\":\"UTC+05:30\",\"abbreviation\":\"IST\",\"tzName\":\"Indian Standard Time\"}]"
+  }
+]
+```
+
+```json 200 - Coordinates tier (Supporter) — basic plus
+[
   {
-    "id": 233,
-    "name": "United States",
-    "iso2": "US",
-    "iso3": "USA",
-    "phonecode": "1",
-    "capital": "Washington",
-    "currency": "USD",
-    "native": "United States",
-    "emoji": "🇺🇸"
+    "id": 101,
+    "name": "India",
+    "...": "...all basic fields above...",
+    "numeric_code": "356",
+    "currency_name": "Indian rupee",
+    "currency_symbol": "₹",
+    "tld": ".in",
+    "nationality": "Indian",
+    "population": 1380004385,
+    "gdp": 2870504000000,
+    "area_sq_km": 3287263,
+    "postal_code_format": "######",
+    "postal_code_regex": "^(\\d{6})$",
+    "emojiU": "U+1F1EE U+1F1F3"
+  }
+]
+```
+
+```json 200 - Full tier (Professional, Business) — coordinates plus
+[
+  {
+    "id": 101,
+    "name": "India",
+    "...": "...all coordinates fields above...",
+    "translations": "{\"kr\":\"인도\",\"de\":\"Indien\",\"es\":\"India\",\"fr\":\"Inde\",\"ja\":\"インド\"}",
+    "wikiDataId": "Q668"
   }
 ]
 ```
@@ -205,6 +264,18 @@ puts JSON.pretty_generate(countries)
 }
 ```
 </ResponseExample>
+
+## Tier-Based Field Availability
+
+The fields returned depend on your plan's data access level.
+
+| Tier | Plans | Fields |
+|------|-------|--------|
+| **Basic** | Community, Starter, Legacy | `id`, `name`, `iso2`, `iso3`, `phonecode`, `capital`, `currency`, `native`, `emoji`, `latitude`, `longitude`, `region`, `region_id`, `subregion`, `subregion_id`, `timezones` |
+| **Coordinates** | Supporter | All Basic **+** `numeric_code`, `currency_name`, `currency_symbol`, `tld`, `nationality`, `population`, `gdp`, `area_sq_km`, `postal_code_format`, `postal_code_regex`, `emojiU` |
+| **Full** | Professional, Business | All Coordinates **+** `translations`, `wikiDataId` |
+
+See [Pricing](https://app.countrystatecity.in/pricing) for plan details.
 
 ## Common Use Cases
 

--- a/api/endpoints/get-all-states.mdx
+++ b/api/endpoints/get-all-states.mdx
@@ -41,10 +41,6 @@ Retrieve a complete list of all states, provinces, regions, and territories from
   ISO2 code for the state/province
 </ResponseField>
 
-<ResponseField name="type" type="string">
-  Administrative division type (e.g., "state", "province", "region")
-</ResponseField>
-
 <ResponseField name="latitude" type="string">
   Approximate latitude coordinate of the state/province center
 </ResponseField>
@@ -52,6 +48,16 @@ Retrieve a complete list of all states, provinces, regions, and territories from
 <ResponseField name="longitude" type="string">
   Approximate longitude coordinate of the state/province center
 </ResponseField>
+
+<ResponseField name="timezone" type="string">
+  IANA timezone identifier (e.g., `"Asia/Kolkata"`)
+</ResponseField>
+
+<ResponseField name="type" type="string">
+  Administrative division type (e.g., `"state"`, `"province"`, `"region"`). **Coordinates tier and above.**
+</ResponseField>
+
+<Info>Additional fields like `fips_code`, `iso3166_2`, `level`, `parent_id`, `native`, `population`, `translations`, and `wikiDataId` are returned on higher tiers. See **Tier-Based Field Availability** below.</Info>
 
 <RequestExample>
 ```bash cURL
@@ -184,7 +190,7 @@ puts "Found #{states.length} states"
 </RequestExample>
 
 <ResponseExample>
-```json 200 - Success
+```json 200 - Basic tier (Community, Starter, Legacy)
 [
   {
     "id": 4008,
@@ -192,19 +198,31 @@ puts "Found #{states.length} states"
     "country_id": 101,
     "country_code": "IN",
     "iso2": "MH",
-    "type": "state",
     "latitude": "19.75147980",
-    "longitude": "75.71388840"
-  },
+    "longitude": "75.71388840",
+    "timezone": "Asia/Kolkata"
+  }
+]
+```
+
+```json 200 - Coordinates tier (Supporter) — basic plus
+[
   {
-    "id": 1456,
-    "name": "California",
-    "country_id": 233,
-    "country_code": "US",
-    "iso2": "CA",
+    "id": 4008,
+    "name": "Maharashtra",
+    "country_id": 101,
+    "country_code": "IN",
+    "iso2": "MH",
+    "latitude": "19.75147980",
+    "longitude": "75.71388840",
+    "timezone": "Asia/Kolkata",
+    "fips_code": "16",
+    "iso3166_2": "IN-MH",
     "type": "state",
-    "latitude": "36.17497340",
-    "longitude": "-119.76762120"
+    "level": 1,
+    "parent_id": null,
+    "native": "महाराष्ट्र",
+    "population": 112374333
   }
 ]
 ```
@@ -257,3 +275,15 @@ puts "Found #{states.length} states"
 <Warning>
 This endpoint returns a large dataset (5000+ states). Consider using the filtered endpoints for better performance in most applications.
 </Warning>
+
+## Tier-Based Field Availability
+
+| Tier | Plans | Fields |
+|------|-------|--------|
+| **Basic** | Community, Starter, Legacy | `id`, `name`, `iso2`, `country_id`, `country_code`, `latitude`, `longitude`, `timezone` |
+| **Coordinates** | Supporter | All Basic **+** `fips_code`, `iso3166_2`, `type`, `level`, `parent_id`, `native`, `population` |
+| **Full** | Professional, Business | All Coordinates **+** `translations`, `wikiDataId` |
+
+<Note>The `bulkStates` feature (calling `/states` without filtering by country) requires **Supporter+**. Community/Starter users must call `/countries/{iso2}/states` instead.</Note>
+
+See [Pricing](https://app.countrystatecity.in/pricing) for plan details.

--- a/api/endpoints/get-cities-by-country.mdx
+++ b/api/endpoints/get-cities-by-country.mdx
@@ -35,6 +35,10 @@ Retrieve all cities within a specific country using the country's ISO2 code. Thi
   Official name of the city
 </ResponseField>
 
+<Info>City responses on the **Basic** tier only return `id` and `name`. Upgrading to **Supporter+** unlocks `state_id`, `state_code`, `country_id`, `country_code`, `latitude`, `longitude`, `timezone`, `population`, `type`, `level`, `parent_id`, and `native`. **Professional+** adds `translations` and `wikiDataId`. See **Tier-Based Field Availability** below.</Info>
+
+<Note>**Availability:** `/countries/{iso2}/cities` (all cities in a country) requires **Supporter+**. Community/Starter users must use [Get Cities by State](/api/endpoints/get-cities-by-state) instead.</Note>
+
 <RequestExample>
 ```bash cURL
 curl -X GET 'https://api.countrystatecity.in/v1/countries/IN/cities' \
@@ -221,19 +225,35 @@ cities = get_cities_by_country('IN')
 </RequestExample>
 
 <ResponseExample>
-```json 200 - Success
+```json 200 - Supporter tier (Coordinates)
 [
   {
     "id": 133024,
-    "name": "Mumbai"
-  },
+    "name": "Mumbai",
+    "state_id": 4008,
+    "state_code": "MH",
+    "country_id": 101,
+    "country_code": "IN",
+    "latitude": "19.07283000",
+    "longitude": "72.88261000",
+    "timezone": "Asia/Kolkata",
+    "population": 12442373,
+    "type": null,
+    "level": null,
+    "parent_id": null,
+    "native": "मुंबई"
+  }
+]
+```
+
+```json 200 - Professional / Business (Full) — coordinates plus
+[
   {
-    "id": 131718,
-    "name": "Delhi"
-  },
-  {
-    "id": 131645,
-    "name": "Bangalore"
+    "id": 133024,
+    "name": "Mumbai",
+    "...": "...all coordinates fields above...",
+    "translations": "{\"de\":\"Mumbai\",\"fr\":\"Bombay\",\"ja\":\"ムンバイ\",\"cn\":\"孟买\"}",
+    "wikiDataId": "Q1156"
   }
 ]
 ```
@@ -315,3 +335,13 @@ cities = get_cities_by_country('IN')
 <Tip>
 For better user experience, consider loading cities by state instead of by country for countries with many administrative divisions.
 </Tip>
+
+## Tier-Based Field Availability
+
+| Tier | Plans | Fields |
+|------|-------|--------|
+| **Basic** | Community, Starter, Legacy | `id`, `name` |
+| **Coordinates** | Supporter | All Basic **+** `state_id`, `state_code`, `country_id`, `country_code`, `latitude`, `longitude`, `timezone`, `population`, `type`, `level`, `parent_id`, `native` |
+| **Full** | Professional, Business | All Coordinates **+** `translations`, `wikiDataId` |
+
+See [Pricing](https://app.countrystatecity.in/pricing) for plan details.

--- a/api/endpoints/get-cities-by-state.mdx
+++ b/api/endpoints/get-cities-by-state.mdx
@@ -39,6 +39,8 @@ Retrieve all cities within a specific state or province using both the country's
   Official name of the city
 </ResponseField>
 
+<Info>City responses on the **Basic** tier only return `id` and `name`. Upgrading to **Supporter+** unlocks `state_id`, `state_code`, `country_id`, `country_code`, `latitude`, `longitude`, `timezone`, `population`, `type`, `level`, `parent_id`, and `native`. **Professional+** adds `translations` and `wikiDataId`. See **Tier-Based Field Availability** below.</Info>
+
 <RequestExample>
 ```bash cURL
 curl -X GET 'https://api.countrystatecity.in/v1/countries/IN/states/MH/cities' \
@@ -231,19 +233,43 @@ cities = get_cities_by_state('IN', 'MH')
 </RequestExample>
 
 <ResponseExample>
-```json 200 - Success
+```json 200 - Basic tier (Community, Starter, Legacy)
+[
+  { "id": 133024, "name": "Mumbai" },
+  { "id": 132332, "name": "Pune" },
+  { "id": 133351, "name": "Nashik" }
+]
+```
+
+```json 200 - Supporter tier (Coordinates)
 [
   {
     "id": 133024,
-    "name": "Mumbai"
-  },
+    "name": "Mumbai",
+    "state_id": 4008,
+    "state_code": "MH",
+    "country_id": 101,
+    "country_code": "IN",
+    "latitude": "19.07283000",
+    "longitude": "72.88261000",
+    "timezone": "Asia/Kolkata",
+    "population": 12442373,
+    "type": null,
+    "level": null,
+    "parent_id": null,
+    "native": "मुंबई"
+  }
+]
+```
+
+```json 200 - Professional / Business (Full) — coordinates plus
+[
   {
-    "id": 132332,
-    "name": "Pune"
-  },
-  {
-    "id": 133351,
-    "name": "Nashik"
+    "id": 133024,
+    "name": "Mumbai",
+    "...": "...all coordinates fields above...",
+    "translations": "{\"de\":\"Mumbai\",\"fr\":\"Bombay\",\"ja\":\"ムンバイ\",\"cn\":\"孟买\"}",
+    "wikiDataId": "Q1156"
   }
 ]
 ```
@@ -351,3 +377,13 @@ This is the most efficient endpoint for building cascading location selectors as
 <Info>
 This endpoint provides the optimal balance between data size and specificity, making it ideal for form controls and location-based filtering.
 </Info>
+
+## Tier-Based Field Availability
+
+| Tier | Plans | Fields |
+|------|-------|--------|
+| **Basic** | Community, Starter, Legacy | `id`, `name` |
+| **Coordinates** | Supporter | All Basic **+** `state_id`, `state_code`, `country_id`, `country_code`, `latitude`, `longitude`, `timezone`, `population`, `type`, `level`, `parent_id`, `native` |
+| **Full** | Professional, Business | All Coordinates **+** `translations`, `wikiDataId` |
+
+See [Pricing](https://app.countrystatecity.in/pricing) for plan details.

--- a/api/endpoints/get-countries-by-subregion.mdx
+++ b/api/endpoints/get-countries-by-subregion.mdx
@@ -48,11 +48,56 @@ console.log(countries);
 </RequestExample>
 
 <ResponseExample>
-```json 200 - Success
+```json 200 - Supporter tier (Coordinates) — abridged
 [
-  { "id": 101, "name": "India", "iso2": "IN", "iso3": "IND" },
-  { "id": 167, "name": "Pakistan", "iso2": "PK", "iso3": "PAK" },
-  { "id": 19, "name": "Bangladesh", "iso2": "BD", "iso3": "BGD" }
+  {
+    "id": 101,
+    "name": "India",
+    "iso2": "IN",
+    "iso3": "IND",
+    "phonecode": "91",
+    "capital": "New Delhi",
+    "currency": "INR",
+    "currency_name": "Indian rupee",
+    "currency_symbol": "₹",
+    "tld": ".in",
+    "nationality": "Indian",
+    "native": "भारत",
+    "emoji": "🇮🇳",
+    "emojiU": "U+1F1EE U+1F1F3",
+    "latitude": "20.00000000",
+    "longitude": "77.00000000",
+    "region": "Asia",
+    "region_id": 3,
+    "subregion": "Southern Asia",
+    "subregion_id": 14,
+    "timezones": "[{\"zoneName\":\"Asia/Kolkata\",\"gmtOffset\":19800,\"gmtOffsetName\":\"UTC+05:30\",\"abbreviation\":\"IST\",\"tzName\":\"Indian Standard Time\"}]",
+    "population": 1380004385,
+    "gdp": 2870504000000,
+    "area_sq_km": 3287263,
+    "postal_code_format": "######",
+    "postal_code_regex": "^(\\d{6})$",
+    "numeric_code": "356"
+  }
 ]
 ```
+
+```json 403 - Feature Restricted
+{
+  "error": "This feature is not available on your current plan.",
+  "feature": "regionsApi",
+  "upgradeUrl": "https://app.countrystatecity.in/pricing"
+}
+```
 </ResponseExample>
+
+## Tier-Based Field Availability
+
+This endpoint requires **Supporter+**, so the **Basic** tier never applies. Returned country fields match [Get Country Details](/api/endpoints/get-country-details):
+
+| Tier | Plans | Fields |
+|------|-------|--------|
+| **Coordinates** | Supporter | `id`, `name`, `iso2`, `iso3`, `phonecode`, `capital`, `currency`, `currency_name`, `currency_symbol`, `tld`, `nationality`, `native`, `emoji`, `emojiU`, `latitude`, `longitude`, `region`, `region_id`, `subregion`, `subregion_id`, `timezones`, `numeric_code`, `population`, `gdp`, `area_sq_km`, `postal_code_format`, `postal_code_regex` |
+| **Full** | Professional, Business | All Coordinates **+** `translations`, `wikiDataId` |
+
+See [Pricing](https://app.countrystatecity.in/pricing) for plan details.

--- a/api/endpoints/get-country-details.mdx
+++ b/api/endpoints/get-country-details.mdx
@@ -102,7 +102,39 @@ Retrieve detailed information for a specific country using its ISO2 code, includ
 </ResponseField>
 
 <ResponseField name="emojiU" type="string">
-  Unicode representation of the flag emoji
+  Unicode representation of the flag emoji. **Coordinates tier and above.**
+</ResponseField>
+
+<ResponseField name="region_id" type="integer">
+  Geographic region ID (foreign key into `/regions`). **Basic tier.**
+</ResponseField>
+
+<ResponseField name="subregion_id" type="integer">
+  Geographic subregion ID (foreign key into `/subregions`). **Basic tier.**
+</ResponseField>
+
+<ResponseField name="population" type="integer">
+  Population estimate. **Coordinates tier and above.**
+</ResponseField>
+
+<ResponseField name="gdp" type="integer">
+  Nominal GDP in USD. **Coordinates tier and above.**
+</ResponseField>
+
+<ResponseField name="area_sq_km" type="integer">
+  Surface area in square kilometres. **Coordinates tier and above.**
+</ResponseField>
+
+<ResponseField name="postal_code_format" type="string">
+  Display template for postal codes (`#` = digit, `@` = letter). **Coordinates tier and above.**
+</ResponseField>
+
+<ResponseField name="postal_code_regex" type="string">
+  Regex for postal-code validation. **Coordinates tier and above.**
+</ResponseField>
+
+<ResponseField name="wikiDataId" type="string">
+  Wikidata item identifier. **Full tier only.**
 </ResponseField>
 
 <RequestExample>
@@ -261,7 +293,7 @@ get_country_details('IN')
 </RequestExample>
 
 <ResponseExample>
-```json 200 - Success
+```json 200 - Full tier (Professional, Business)
 {
   "id": 101,
   "name": "India",
@@ -285,7 +317,34 @@ get_country_details('IN')
   "latitude": "20.00000000",
   "longitude": "77.00000000",
   "emoji": "🇮🇳",
-  "emojiU": "U+1F1EE U+1F1F3"
+  "emojiU": "U+1F1EE U+1F1F3",
+  "population": 1380004385,
+  "gdp": 2870504000000,
+  "area_sq_km": 3287263,
+  "postal_code_format": "######",
+  "postal_code_regex": "^(\\d{6})$",
+  "wikiDataId": "Q668"
+}
+```
+
+```json 200 - Basic tier (Community, Starter, Legacy)
+{
+  "id": 101,
+  "name": "India",
+  "iso2": "IN",
+  "iso3": "IND",
+  "phonecode": "91",
+  "capital": "New Delhi",
+  "currency": "INR",
+  "native": "भारत",
+  "emoji": "🇮🇳",
+  "latitude": "20.00000000",
+  "longitude": "77.00000000",
+  "region": "Asia",
+  "region_id": 3,
+  "subregion": "Southern Asia",
+  "subregion_id": 14,
+  "timezones": "[{\"zoneName\":\"Asia/Kolkata\",\"gmtOffset\":19800,\"gmtOffsetName\":\"UTC+05:30\",\"abbreviation\":\"IST\",\"tzName\":\"Indian Standard Time\"}]"
 }
 ```
 
@@ -337,3 +396,13 @@ get_country_details('IN')
 <Tip>
 Use this endpoint when you need detailed country information for user profiles, shipping calculations, or localization features.
 </Tip>
+
+## Tier-Based Field Availability
+
+| Tier | Plans | Fields |
+|------|-------|--------|
+| **Basic** | Community, Starter, Legacy | `id`, `name`, `iso2`, `iso3`, `phonecode`, `capital`, `currency`, `native`, `emoji`, `latitude`, `longitude`, `region`, `region_id`, `subregion`, `subregion_id`, `timezones` |
+| **Coordinates** | Supporter | All Basic **+** `numeric_code`, `currency_name`, `currency_symbol`, `tld`, `nationality`, `population`, `gdp`, `area_sq_km`, `postal_code_format`, `postal_code_regex`, `emojiU` |
+| **Full** | Professional, Business | All Coordinates **+** `translations`, `wikiDataId` |
+
+See [Pricing](https://app.countrystatecity.in/pricing) for plan details.

--- a/api/endpoints/get-currency-by-country.mdx
+++ b/api/endpoints/get-currency-by-country.mdx
@@ -1,0 +1,131 @@
+---
+title: "Get Currency by Country"
+api: "GET https://api.countrystatecity.in/v1/currency/{ciso}"
+authMethod: "key"
+description: "Retrieve the official currency for a single country by ISO2, ISO3, or numeric ID"
+---
+
+Retrieve the currency used by a single country. The path parameter accepts **three forms** for flexibility:
+
+- ISO 3166-1 alpha-2 code (e.g., `US`, `IN`)
+- ISO 3166-1 alpha-3 code (e.g., `USA`, `IND`)
+- Numeric country ID (e.g., `233` for the United States in our database)
+
+<Note>**Availability:** Supporter plan and above. Returns `403` on lower tiers.</Note>
+
+<Info>Responses are cached server-side for 24 hours. Equivalent identifier forms (e.g., `1` and `001`) resolve to the same cache slot.</Info>
+
+## Authentication
+
+<ParamField header="X-CSCAPI-KEY" type="string" required>
+  Your API key for authentication
+</ParamField>
+
+## Path Parameters
+
+<ParamField path="ciso" type="string" required>
+  ISO2 code, ISO3 code, or numeric country ID. Case-insensitive for ISO codes.
+</ParamField>
+
+## Response
+
+<ResponseField name="country" type="string">
+  ISO2 code of the country (e.g., `"US"`)
+</ResponseField>
+
+<ResponseField name="currency" type="object">
+  Currency information
+  <Expandable title="properties">
+    <ResponseField name="code" type="string">
+      ISO 4217 currency code (e.g., `"USD"`). Always present — endpoint returns `404` if the country has no currency on record.
+    </ResponseField>
+    <ResponseField name="name" type="string | null">
+      Full currency name (e.g., `"United States dollar"`). May be `null` for edge-case territories.
+    </ResponseField>
+    <ResponseField name="symbol" type="string | null">
+      Unicode currency symbol (e.g., `"$"`). May be `null` — fall back to `code` when rendering.
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<RequestExample>
+```bash cURL (ISO2)
+curl -X GET 'https://api.countrystatecity.in/v1/currency/US' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```bash cURL (ISO3)
+curl -X GET 'https://api.countrystatecity.in/v1/currency/IND' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```javascript JavaScript
+const response = await fetch('https://api.countrystatecity.in/v1/currency/US', {
+  headers: { 'X-CSCAPI-KEY': 'YOUR_API_KEY' }
+});
+
+const { currency } = await response.json();
+console.log(`${currency.symbol} ${currency.code}`);
+```
+
+```python Python
+import requests
+
+response = requests.get(
+  'https://api.countrystatecity.in/v1/currency/US',
+  headers={'X-CSCAPI-KEY': 'YOUR_API_KEY'}
+)
+
+data = response.json()
+print(f"{data['country']} uses {data['currency']['code']}")
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200 - Success
+{
+  "country": "US",
+  "currency": {
+    "code": "USD",
+    "name": "United States dollar",
+    "symbol": "$"
+  }
+}
+```
+
+```json 200 - Edge case (symbol null)
+{
+  "country": "CU",
+  "currency": {
+    "code": "CUP",
+    "name": "Cuban peso",
+    "symbol": null
+  }
+}
+```
+
+```json 403 - Feature Restricted
+{
+  "error": "This feature is not available on your current plan.",
+  "feature": "currencyApi",
+  "upgradeUrl": "https://app.countrystatecity.in/pricing"
+}
+```
+
+```json 404 - Country Not Found
+{
+  "error": "Country not found."
+}
+```
+
+```json 404 - No Currency Data
+{
+  "error": "No currency data available for this country."
+}
+```
+</ResponseExample>
+
+## Related Endpoints
+
+- [List All Currencies](/api/endpoints/list-all-currencies) — every country's currency in one call, with optional reverse lookup
+- [Get Country Details](/api/endpoints/get-country-details) — full country record including currency fields inline

--- a/api/endpoints/get-region-details.mdx
+++ b/api/endpoints/get-region-details.mdx
@@ -1,0 +1,106 @@
+---
+title: "Get Region Details"
+api: "GET https://api.countrystatecity.in/v1/regions/{id}"
+authMethod: "key"
+description: "Retrieve a single geographic region by its numeric ID"
+---
+
+Retrieve detailed information for a single geographic region (e.g., Africa, Americas, Asia, Europe, Oceania, Polar) by its numeric ID.
+
+<Note>**Availability:** Supporter plan and above. Returns `403` on lower tiers.</Note>
+
+## Authentication
+
+<ParamField header="X-CSCAPI-KEY" type="string" required>
+  Your API key for authentication
+</ParamField>
+
+## Path Parameters
+
+<ParamField path="id" type="integer" required>
+  Numeric region ID (e.g., `3` for Asia, `4` for Europe)
+</ParamField>
+
+## Response
+
+<ResponseField name="id" type="integer">
+  Unique identifier for the region
+</ResponseField>
+
+<ResponseField name="name" type="string">
+  Region name (e.g., Asia, Europe)
+</ResponseField>
+
+<ResponseField name="wikiDataId" type="string">
+  Wikidata item identifier. **Coordinates tier and above.**
+</ResponseField>
+
+<ResponseField name="translations" type="string">
+  JSON string of region name translations in 18+ languages. **Full access level only.**
+</ResponseField>
+
+<RequestExample>
+```bash cURL
+curl -X GET 'https://api.countrystatecity.in/v1/regions/3' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```javascript JavaScript
+const response = await fetch('https://api.countrystatecity.in/v1/regions/3', {
+  headers: { 'X-CSCAPI-KEY': 'YOUR_API_KEY' }
+});
+
+const region = await response.json();
+console.log(region);
+```
+
+```python Python
+import requests
+
+response = requests.get(
+  'https://api.countrystatecity.in/v1/regions/3',
+  headers={'X-CSCAPI-KEY': 'YOUR_API_KEY'}
+)
+
+region = response.json()
+print(region)
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200 - Success (Supporter tier)
+{
+  "id": 3,
+  "name": "Asia",
+  "wikiDataId": "Q48"
+}
+```
+
+```json 200 - Success (Professional / Business tier)
+{
+  "id": 3,
+  "name": "Asia",
+  "wikiDataId": "Q48",
+  "translations": "{\"kr\":\"아시아\",\"pt\":\"Ásia\",\"nl\":\"Azië\",\"hr\":\"Azija\",\"fa\":\"آسیا\",\"de\":\"Asien\",\"es\":\"Asia\",\"fr\":\"Asie\",\"ja\":\"アジア\",\"it\":\"Asia\",\"cn\":\"亚洲\",\"tr\":\"Asya\"}"
+}
+```
+
+```json 403 - Feature Restricted
+{
+  "error": "This feature is not available on your current plan.",
+  "feature": "regionsApi",
+  "upgradeUrl": "https://app.countrystatecity.in/pricing"
+}
+```
+
+```json 404 - Not Found
+{
+  "error": "Region not found."
+}
+```
+</ResponseExample>
+
+## Related Endpoints
+
+- [Get All Regions](/api/endpoints/get-all-regions) — list every region
+- [Get Subregions of a Region](/api/endpoints/get-subregions-by-region) — drill down into subregions

--- a/api/endpoints/get-state-details.mdx
+++ b/api/endpoints/get-state-details.mdx
@@ -45,10 +45,6 @@ Retrieve detailed information for a specific state or province using the country
   ISO2 code for the state/province
 </ResponseField>
 
-<ResponseField name="type" type="string">
-  Administrative division type (e.g., "state", "province", "region")
-</ResponseField>
-
 <ResponseField name="latitude" type="string">
   Approximate latitude coordinate of the state/province center
 </ResponseField>
@@ -56,6 +52,16 @@ Retrieve detailed information for a specific state or province using the country
 <ResponseField name="longitude" type="string">
   Approximate longitude coordinate of the state/province center
 </ResponseField>
+
+<ResponseField name="timezone" type="string">
+  IANA timezone identifier (e.g., `"Asia/Kolkata"`)
+</ResponseField>
+
+<ResponseField name="type" type="string">
+  Administrative division type (e.g., `"state"`, `"province"`, `"region"`). **Coordinates tier and above.**
+</ResponseField>
+
+<Info>Additional fields like `fips_code`, `iso3166_2`, `level`, `parent_id`, `native`, `population`, `translations`, and `wikiDataId` are returned on higher tiers. See **Tier-Based Field Availability** below.</Info>
 
 <RequestExample>
 ```bash cURL
@@ -241,16 +247,36 @@ state = get_state_details('IN', 'MH')
 </RequestExample>
 
 <ResponseExample>
-```json 200 - Success
+```json 200 - Basic tier (Community, Starter, Legacy)
 {
   "id": 4008,
   "name": "Maharashtra",
   "country_id": 101,
   "country_code": "IN",
   "iso2": "MH",
-  "type": "state",
   "latitude": "19.75147980",
-  "longitude": "75.71388840"
+  "longitude": "75.71388840",
+  "timezone": "Asia/Kolkata"
+}
+```
+
+```json 200 - Coordinates tier (Supporter) — basic plus
+{
+  "id": 4008,
+  "name": "Maharashtra",
+  "country_id": 101,
+  "country_code": "IN",
+  "iso2": "MH",
+  "latitude": "19.75147980",
+  "longitude": "75.71388840",
+  "timezone": "Asia/Kolkata",
+  "fips_code": "16",
+  "iso3166_2": "IN-MH",
+  "type": "state",
+  "level": 1,
+  "parent_id": null,
+  "native": "महाराष्ट्र",
+  "population": 112374333
 }
 ```
 
@@ -313,3 +339,13 @@ state = get_state_details('IN', 'MH')
 <Tip>
 Use this endpoint when you need precise geographical coordinates or want to validate specific state/country combinations.
 </Tip>
+
+## Tier-Based Field Availability
+
+| Tier | Plans | Fields |
+|------|-------|--------|
+| **Basic** | Community, Starter, Legacy | `id`, `name`, `iso2`, `country_id`, `country_code`, `latitude`, `longitude`, `timezone` |
+| **Coordinates** | Supporter | All Basic **+** `fips_code`, `iso3166_2`, `type`, `level`, `parent_id`, `native`, `population` |
+| **Full** | Professional, Business | All Coordinates **+** `translations`, `wikiDataId` |
+
+See [Pricing](https://app.countrystatecity.in/pricing) for plan details.

--- a/api/endpoints/get-states-by-country.mdx
+++ b/api/endpoints/get-states-by-country.mdx
@@ -39,6 +39,28 @@ Retrieve all states, provinces, regions, and territories for a specific country 
   ISO2 code for the state/province
 </ResponseField>
 
+<ResponseField name="country_id" type="integer">
+  Unique identifier of the parent country
+</ResponseField>
+
+<ResponseField name="country_code" type="string">
+  ISO2 code of the parent country
+</ResponseField>
+
+<ResponseField name="latitude" type="string">
+  Approximate latitude of the state/province
+</ResponseField>
+
+<ResponseField name="longitude" type="string">
+  Approximate longitude of the state/province
+</ResponseField>
+
+<ResponseField name="timezone" type="string">
+  IANA timezone identifier (e.g., `"Asia/Kolkata"`)
+</ResponseField>
+
+<Info>Additional fields like `fips_code`, `iso3166_2`, `type`, `level`, `parent_id`, `native`, `population`, `translations`, and `wikiDataId` are returned on higher tiers. See **Tier-Based Field Availability** below.</Info>
+
 <RequestExample>
 ```bash cURL
 curl -X GET 'https://api.countrystatecity.in/v1/countries/IN/states' \
@@ -224,22 +246,39 @@ states = get_states_by_country('IN')
 </RequestExample>
 
 <ResponseExample>
-```json 200 - Success
+```json 200 - Basic tier (Community, Starter, Legacy)
 [
   {
     "id": 4008,
     "name": "Maharashtra",
-    "iso2": "MH"
-  },
+    "iso2": "MH",
+    "country_id": 101,
+    "country_code": "IN",
+    "latitude": "19.75147980",
+    "longitude": "75.71388840",
+    "timezone": "Asia/Kolkata"
+  }
+]
+```
+
+```json 200 - Coordinates tier (Supporter) — basic plus
+[
   {
-    "id": 4017,
-    "name": "Karnataka",
-    "iso2": "KA"
-  },
-  {
-    "id": 4030,
-    "name": "Tamil Nadu",
-    "iso2": "TN"
+    "id": 4008,
+    "name": "Maharashtra",
+    "iso2": "MH",
+    "country_id": 101,
+    "country_code": "IN",
+    "latitude": "19.75147980",
+    "longitude": "75.71388840",
+    "timezone": "Asia/Kolkata",
+    "fips_code": "16",
+    "iso3166_2": "IN-MH",
+    "type": "state",
+    "level": 1,
+    "parent_id": null,
+    "native": "महाराष्ट्र",
+    "population": 112374333
   }
 ]
 ```
@@ -301,3 +340,13 @@ states = get_states_by_country('IN')
 <Tip>
 Cache states by country as they rarely change. Use this endpoint instead of filtering all states for better performance.
 </Tip>
+
+## Tier-Based Field Availability
+
+| Tier | Plans | Fields |
+|------|-------|--------|
+| **Basic** | Community, Starter, Legacy | `id`, `name`, `iso2`, `country_id`, `country_code`, `latitude`, `longitude`, `timezone` |
+| **Coordinates** | Supporter | All Basic **+** `fips_code`, `iso3166_2`, `type`, `level`, `parent_id`, `native`, `population` |
+| **Full** | Professional, Business | All Coordinates **+** `translations`, `wikiDataId` |
+
+See [Pricing](https://app.countrystatecity.in/pricing) for plan details.

--- a/api/endpoints/get-subregion-details.mdx
+++ b/api/endpoints/get-subregion-details.mdx
@@ -1,0 +1,112 @@
+---
+title: "Get Subregion Details"
+api: "GET https://api.countrystatecity.in/v1/subregions/{id}"
+authMethod: "key"
+description: "Retrieve a single subregion by its numeric ID"
+---
+
+Retrieve detailed information for a single subregion (e.g., Southern Asia, Western Europe, Caribbean) by its numeric ID.
+
+<Note>**Availability:** Supporter plan and above. Returns `403` on lower tiers.</Note>
+
+## Authentication
+
+<ParamField header="X-CSCAPI-KEY" type="string" required>
+  Your API key for authentication
+</ParamField>
+
+## Path Parameters
+
+<ParamField path="id" type="integer" required>
+  Numeric subregion ID (e.g., `14` for Southern Asia)
+</ParamField>
+
+## Response
+
+<ResponseField name="id" type="integer">
+  Unique identifier for the subregion
+</ResponseField>
+
+<ResponseField name="name" type="string">
+  Subregion name (e.g., Southern Asia)
+</ResponseField>
+
+<ResponseField name="region_id" type="integer">
+  Parent region ID
+</ResponseField>
+
+<ResponseField name="wikiDataId" type="string">
+  Wikidata item identifier. **Coordinates tier and above.**
+</ResponseField>
+
+<ResponseField name="translations" type="string">
+  JSON string of subregion name translations in 18+ languages. **Full access level only.**
+</ResponseField>
+
+<RequestExample>
+```bash cURL
+curl -X GET 'https://api.countrystatecity.in/v1/subregions/14' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```javascript JavaScript
+const response = await fetch('https://api.countrystatecity.in/v1/subregions/14', {
+  headers: { 'X-CSCAPI-KEY': 'YOUR_API_KEY' }
+});
+
+const subregion = await response.json();
+console.log(subregion);
+```
+
+```python Python
+import requests
+
+response = requests.get(
+  'https://api.countrystatecity.in/v1/subregions/14',
+  headers={'X-CSCAPI-KEY': 'YOUR_API_KEY'}
+)
+
+subregion = response.json()
+print(subregion)
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200 - Success (Supporter tier)
+{
+  "id": 14,
+  "name": "Southern Asia",
+  "region_id": 3,
+  "wikiDataId": "Q771405"
+}
+```
+
+```json 200 - Success (Professional / Business tier)
+{
+  "id": 14,
+  "name": "Southern Asia",
+  "region_id": 3,
+  "wikiDataId": "Q771405",
+  "translations": "{\"fr\":\"Asie du Sud\",\"de\":\"Südasien\",\"es\":\"Asia meridional\",\"ja\":\"南アジア\",\"cn\":\"南亚\"}"
+}
+```
+
+```json 403 - Feature Restricted
+{
+  "error": "This feature is not available on your current plan.",
+  "feature": "regionsApi",
+  "upgradeUrl": "https://app.countrystatecity.in/pricing"
+}
+```
+
+```json 404 - Not Found
+{
+  "error": "Subregion not found."
+}
+```
+</ResponseExample>
+
+## Related Endpoints
+
+- [Get Subregions of a Region](/api/endpoints/get-subregions-by-region) — list subregions for a parent region
+- [Get Countries in a Subregion](/api/endpoints/get-countries-by-subregion) — drill into countries

--- a/api/endpoints/list-all-currencies.mdx
+++ b/api/endpoints/list-all-currencies.mdx
@@ -1,0 +1,131 @@
+---
+title: "List All Currencies"
+api: "GET https://api.countrystatecity.in/v1/currency"
+authMethod: "key"
+description: "Retrieve the currency used by every country, with optional reverse lookup by ISO 4217 code"
+---
+
+Retrieve the currency mapping for every country in the database. Each item links a country (by ISO2) to its currency `code`, `name`, and `symbol`. Use the optional `?code=` query parameter to perform a reverse lookup and find every country that uses a given ISO 4217 currency code (e.g., all Eurozone countries).
+
+<Note>**Availability:** Supporter plan and above. Returns `403` on lower tiers.</Note>
+
+<Info>The list is alphabetically ordered by country ISO2 and excludes countries without currency data (~0.1% of records). Results are cached server-side for 24 hours.</Info>
+
+## Authentication
+
+<ParamField header="X-CSCAPI-KEY" type="string" required>
+  Your API key for authentication
+</ParamField>
+
+## Query Parameters
+
+<ParamField query="code" type="string">
+  Optional ISO 4217 currency code (3 letters, case-insensitive). When set, returns only countries that use that currency. Invalid codes return `400`.
+</ParamField>
+
+## Response
+
+Returns an array of objects with this shape:
+
+<ResponseField name="country" type="string">
+  ISO2 code of the country (e.g., `"US"`, `"IN"`, `"FR"`)
+</ResponseField>
+
+<ResponseField name="currency" type="object">
+  Currency information
+  <Expandable title="properties">
+    <ResponseField name="code" type="string">
+      ISO 4217 currency code (e.g., `"USD"`, `"EUR"`). Always present.
+    </ResponseField>
+    <ResponseField name="name" type="string | null">
+      Full currency name (e.g., `"United States dollar"`). May be `null` for edge-case territories.
+    </ResponseField>
+    <ResponseField name="symbol" type="string | null">
+      Unicode currency symbol (e.g., `"$"`, `"€"`, `"₹"`). May be `null` — clients should fall back to `code` when rendering.
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<RequestExample>
+```bash cURL (all currencies)
+curl -X GET 'https://api.countrystatecity.in/v1/currency' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```bash cURL (Eurozone lookup)
+curl -X GET 'https://api.countrystatecity.in/v1/currency?code=EUR' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```javascript JavaScript
+const response = await fetch('https://api.countrystatecity.in/v1/currency?code=EUR', {
+  headers: { 'X-CSCAPI-KEY': 'YOUR_API_KEY' }
+});
+
+const eurozone = await response.json();
+console.log(`${eurozone.length} countries use EUR`);
+```
+
+```python Python
+import requests
+
+response = requests.get(
+  'https://api.countrystatecity.in/v1/currency',
+  params={'code': 'EUR'},
+  headers={'X-CSCAPI-KEY': 'YOUR_API_KEY'}
+)
+
+eurozone = response.json()
+print(f"{len(eurozone)} countries use EUR")
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200 - Full List (truncated)
+[
+  {
+    "country": "AD",
+    "currency": { "code": "EUR", "name": "Euro", "symbol": "€" }
+  },
+  {
+    "country": "AE",
+    "currency": { "code": "AED", "name": "United Arab Emirates dirham", "symbol": "د.إ" }
+  },
+  {
+    "country": "AF",
+    "currency": { "code": "AFN", "name": "Afghan afghani", "symbol": "؋" }
+  }
+]
+```
+
+```json 200 - Filtered (?code=EUR)
+[
+  { "country": "AD", "currency": { "code": "EUR", "name": "Euro", "symbol": "€" } },
+  { "country": "AT", "currency": { "code": "EUR", "name": "Euro", "symbol": "€" } },
+  { "country": "BE", "currency": { "code": "EUR", "name": "Euro", "symbol": "€" } },
+  { "country": "DE", "currency": { "code": "EUR", "name": "Euro", "symbol": "€" } },
+  { "country": "FR", "currency": { "code": "EUR", "name": "Euro", "symbol": "€" } }
+]
+```
+
+```json 400 - Bad Request
+{
+  "status": 400,
+  "message": "Invalid currency code. Must be a 3-letter ISO 4217 code (e.g., USD, EUR).",
+  "details": null
+}
+```
+
+```json 403 - Feature Restricted
+{
+  "error": "This feature is not available on your current plan.",
+  "feature": "currencyApi",
+  "upgradeUrl": "https://app.countrystatecity.in/pricing"
+}
+```
+</ResponseExample>
+
+## Related Endpoints
+
+- [Get Currency by Country](/api/endpoints/get-currency-by-country) — fetch the currency for a single country
+- [Get Country Details](/api/endpoints/get-country-details) — full country record (includes currency fields inline)

--- a/docs.json
+++ b/docs.json
@@ -59,8 +59,17 @@
             "group": "Regions Endpoints",
             "pages": [
               "api/endpoints/get-all-regions",
+              "api/endpoints/get-region-details",
               "api/endpoints/get-subregions-by-region",
+              "api/endpoints/get-subregion-details",
               "api/endpoints/get-countries-by-subregion"
+            ]
+          },
+          {
+            "group": "Currency Endpoints",
+            "pages": [
+              "api/endpoints/list-all-currencies",
+              "api/endpoints/get-currency-by-country"
             ]
           },
           {


### PR DESCRIPTION
## Summary

Brings the Mintlify docs back in sync with the live `/v1/*` geographic API.

**Four new endpoint pages** (registered in `docs.json`):
- `GET /v1/regions/:id` — single region by numeric ID
- `GET /v1/subregions/:id` — single subregion by numeric ID
- `GET /v1/currency` — all country→currency mappings, with optional `?code=` reverse lookup (e.g. find all Eurozone countries)
- `GET /v1/currency/:ciso` — currency for a single country; accepts ISO2, ISO3, or numeric ID

A new **Currency Endpoints** group is added to the sidebar; region detail pages slot into the existing **Regions Endpoints** group.

**Refresh of existing endpoint docs** (8 files):
- Filled in basic-tier fields that were silently omitted (`latitude`, `longitude`, `region(_id)`, `subregion(_id)`, `timezones` for countries; `country_id`, `country_code`, `latitude`, `longitude`, `timezone` for states-by-country).
- **Bug fix:** `type` on state endpoints was incorrectly listed as basic-tier; it's actually only returned on Supporter+ (`dataAccessService.ts`).
- Added a consistent **Tier-Based Field Availability** matrix at the bottom of every endpoint doc, mapping each plan (Community / Starter / Legacy / Supporter / Professional / Business) to the fields it receives.
- Updated response examples to show per-tier payloads where they materially differ.

The tier matrices were derived directly from `csc-app/api/src/services/dataAccessService.ts`, so they reflect the actual server-side filtering logic.

## Test plan

- [ ] `mint dev` (or `npm run dev`) and confirm sidebar shows new pages under **Regions Endpoints** and the new **Currency Endpoints** group
- [ ] Open each of the 4 new pages and verify the GET badge, params, and request/response examples render
- [ ] Open each of the 8 refreshed pages and verify the Tier-Based Field Availability matrix renders as a table
- [ ] Spot-check `get-all-states.mdx` and `get-state-details.mdx` — confirm `type` is now flagged as Coordinates-tier
- [ ] No broken internal links (Mintlify will flag these on build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)