### PR TITLE
docs: surface per-route plan availability on every endpoint page

### DIFF
--- a/api/endpoints/get-all-countries.mdx
+++ b/api/endpoints/get-all-countries.mdx
@@ -7,6 +7,8 @@ description: "Retrieve a complete list of all countries with basic information"
 
 Retrieve a complete list of all countries with basic information including ISO codes, phone codes, currencies, and regional data.
 
+<Note>**Availability:** All plans (Community and above). The fields returned vary by tier — see **Tier-Based Field Availability** below.</Note>
+
 ## Authentication
 
 <ParamField header="X-CSCAPI-KEY" type="string" required>

--- a/api/endpoints/get-all-states.mdx
+++ b/api/endpoints/get-all-states.mdx
@@ -7,6 +7,8 @@ description: "Retrieve a complete list of all states, provinces, and regions wor
 
 Retrieve a complete list of all states, provinces, regions, and territories from around the world with basic geographical information.
 
+<Note>**Availability:** Supporter plan and above. Calling `/states` without filtering by country (`bulkStates`) is gated to Supporter+. Community/Starter users must call `/countries/{iso2}/states` instead. The fields returned also vary by tier — see **Tier-Based Field Availability** below.</Note>
+
 ## Authentication
 
 <ParamField header="X-CSCAPI-KEY" type="string" required>
@@ -283,7 +285,5 @@ This endpoint returns a large dataset (5000+ states). Consider using the filtere
 | **Basic** | Community, Starter, Legacy | `id`, `name`, `iso2`, `country_id`, `country_code`, `latitude`, `longitude`, `timezone` |
 | **Coordinates** | Supporter | All Basic **+** `fips_code`, `iso3166_2`, `type`, `level`, `parent_id`, `native`, `population` |
 | **Full** | Professional, Business | All Coordinates **+** `translations`, `wikiDataId` |
-
-<Note>The `bulkStates` feature (calling `/states` without filtering by country) requires **Supporter+**. Community/Starter users must call `/countries/{iso2}/states` instead.</Note>
 
 See [Pricing](https://app.countrystatecity.in/pricing) for plan details.

--- a/api/endpoints/get-cities-by-state.mdx
+++ b/api/endpoints/get-cities-by-state.mdx
@@ -7,6 +7,8 @@ description: "Retrieve all cities within a specific state/province of a country"
 
 Retrieve all cities within a specific state or province using both the country's ISO2 code and the state's ISO2 code. This provides the most targeted city data.
 
+<Note>**Availability:** All plans (Community and above). The fields returned vary by tier — see **Tier-Based Field Availability** below.</Note>
+
 ## Path Parameters
 
 <ParamField path="country_iso2" type="string" required>

--- a/api/endpoints/get-country-details.mdx
+++ b/api/endpoints/get-country-details.mdx
@@ -7,6 +7,8 @@ description: "Retrieve detailed information for a specific country using its ISO
 
 Retrieve detailed information for a specific country using its ISO2 code, including extended geographical, currency, and timezone data.
 
+<Note>**Availability:** All plans (Community and above). The fields returned vary by tier — see **Tier-Based Field Availability** below.</Note>
+
 ## Path Parameters
 
 <ParamField path="iso2" type="string" required>

--- a/api/endpoints/get-state-details.mdx
+++ b/api/endpoints/get-state-details.mdx
@@ -7,6 +7,8 @@ description: "Retrieve detailed information for a specific state using country a
 
 Retrieve detailed information for a specific state or province using the country's ISO2 code and the state's ISO2 code.
 
+<Note>**Availability:** All plans (Community and above). The fields returned vary by tier — see **Tier-Based Field Availability** below.</Note>
+
 ## Path Parameters
 
 <ParamField path="country_iso2" type="string" required>

--- a/api/endpoints/get-states-by-country.mdx
+++ b/api/endpoints/get-states-by-country.mdx
@@ -7,6 +7,8 @@ description: "Retrieve all states/provinces for a specific country"
 
 Retrieve all states, provinces, regions, and territories for a specific country using the country's ISO2 code.
 
+<Note>**Availability:** All plans (Community and above). The fields returned vary by tier — see **Tier-Based Field Availability** below.</Note>
+
 ## Path Parameters
 
 <ParamField path="iso2" type="string" required>


### PR DESCRIPTION
## Summary

Follow-up to #2. Every endpoint doc now states plan eligibility in a top-level `<Note>` immediately under the page intro, instead of leaving customers to infer from silence.

**Added Availability note to the 5 ungated endpoints** (open to Community and above):
- `get-all-countries.mdx`
- `get-country-details.mdx`
- `get-states-by-country.mdx`
- `get-state-details.mdx`
- `get-cities-by-state.mdx`

**Promoted the `bulkStates` (Supporter+) callout** in `get-all-states.mdx` from inside the Tier-Based Field Availability section up to the top of the page, matching the placement of other gated endpoints (regions, currency, cities-by-country).

Net effect: a customer landing on any endpoint doc can now answer "can my plan call this?" without scrolling.

## Test plan

- [ ] `mint dev` and confirm every endpoint page has a top-level Availability note under the intro paragraph
- [ ] Confirm `get-all-states.mdx` no longer has the duplicate `bulkStates` note inside the tier matrix section
- [ ] Spot-check that gated endpoints (regions, currency) still read coherently — those weren't touched in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)