### PR TITLE
feat: generate tier-availability matrices from csc-app sources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,12 @@ npm run sync-changelog
 
 # Update database statistics from GitHub
 npm run update-database-stats
+
+# Regenerate per-tier field-availability tables from csc-app sources
+npm run sync-tier-matrices
+
+# CI-friendly drift check (exits 1 on drift, no writes)
+npm run check-tier-matrices
 ```
 
 ## Architecture & Structure
@@ -73,8 +79,28 @@ Located in `scripts/` directory:
 
 - **sync-changelog.js**: Fetches and synchronizes changelog data
 - **update-database-stats.js**: Fetches latest stats from GitHub repo and updates `database/overview.mdx`
+- **sync-tier-matrices.js**: Reads `services/dataAccessService.ts` and `config/pricingTiers.ts` from csc-app and rewrites `<!-- AUTOGEN:tier-matrix:<entity> -->` blocks in `api/endpoints/*.mdx`. Source path defaults to `../csc-app/api/src` (sibling checkout); override with `--source <path>` or `CSC_APP_SRC` env. Run `--check` mode in CI to fail on drift.
 
-Both scripts use Node.js 18+ built-in fetch and include comprehensive error handling.
+All scripts use Node.js 18+ built-in fetch and include comprehensive error handling.
+
+### Tier-Matrix Drift Workflow
+
+The "Tier-Based Field Availability" tables in each endpoint doc are generated from csc-app's source-of-truth files. After any change to `dataAccessService.ts` (which fields each access level returns) or `pricingTiers.ts` (which plans map to which `dataAccessLevel`), regenerate the docs:
+
+```bash
+cd /path/to/csc-docs
+npm run sync-tier-matrices
+git diff   # inspect the regenerated tables
+```
+
+To add a tier matrix to a new endpoint doc, wrap a placeholder with the markers and run the generator:
+
+```mdx
+<!-- AUTOGEN:tier-matrix:countries START -->
+<!-- AUTOGEN:tier-matrix:countries END -->
+```
+
+Valid entity names: `countries`, `states`, `cities`, `regions`, `subregions` (whatever keys exist in `FIELD_ACCESS` in csc-app).
 
 ## Writing Guidelines
 

--- a/api/endpoints/get-all-countries.mdx
+++ b/api/endpoints/get-all-countries.mdx
@@ -271,11 +271,13 @@ puts JSON.pretty_generate(countries)
 
 The fields returned depend on your plan's data access level.
 
+<!-- AUTOGEN:tier-matrix:countries START -->
 | Tier | Plans | Fields |
 |------|-------|--------|
 | **Basic** | Community, Starter, Legacy | `id`, `name`, `iso2`, `iso3`, `phonecode`, `capital`, `currency`, `native`, `emoji`, `latitude`, `longitude`, `region`, `region_id`, `subregion`, `subregion_id`, `timezones` |
 | **Coordinates** | Supporter | All Basic **+** `numeric_code`, `currency_name`, `currency_symbol`, `tld`, `nationality`, `population`, `gdp`, `area_sq_km`, `postal_code_format`, `postal_code_regex`, `emojiU` |
 | **Full** | Professional, Business | All Coordinates **+** `translations`, `wikiDataId` |
+<!-- AUTOGEN:tier-matrix:countries END -->
 
 See [Pricing](https://app.countrystatecity.in/pricing) for plan details.
 

--- a/api/endpoints/get-all-states.mdx
+++ b/api/endpoints/get-all-states.mdx
@@ -280,10 +280,12 @@ This endpoint returns a large dataset (5000+ states). Consider using the filtere
 
 ## Tier-Based Field Availability
 
+<!-- AUTOGEN:tier-matrix:states START -->
 | Tier | Plans | Fields |
 |------|-------|--------|
 | **Basic** | Community, Starter, Legacy | `id`, `name`, `iso2`, `country_id`, `country_code`, `latitude`, `longitude`, `timezone` |
 | **Coordinates** | Supporter | All Basic **+** `fips_code`, `iso3166_2`, `type`, `level`, `parent_id`, `native`, `population` |
 | **Full** | Professional, Business | All Coordinates **+** `translations`, `wikiDataId` |
+<!-- AUTOGEN:tier-matrix:states END -->
 
 See [Pricing](https://app.countrystatecity.in/pricing) for plan details.

--- a/api/endpoints/get-cities-by-country.mdx
+++ b/api/endpoints/get-cities-by-country.mdx
@@ -338,10 +338,12 @@ For better user experience, consider loading cities by state instead of by count
 
 ## Tier-Based Field Availability
 
+<!-- AUTOGEN:tier-matrix:cities START -->
 | Tier | Plans | Fields |
 |------|-------|--------|
 | **Basic** | Community, Starter, Legacy | `id`, `name` |
 | **Coordinates** | Supporter | All Basic **+** `state_id`, `state_code`, `country_id`, `country_code`, `latitude`, `longitude`, `timezone`, `population`, `type`, `level`, `parent_id`, `native` |
 | **Full** | Professional, Business | All Coordinates **+** `translations`, `wikiDataId` |
+<!-- AUTOGEN:tier-matrix:cities END -->
 
 See [Pricing](https://app.countrystatecity.in/pricing) for plan details.

--- a/api/endpoints/get-cities-by-state.mdx
+++ b/api/endpoints/get-cities-by-state.mdx
@@ -382,10 +382,12 @@ This endpoint provides the optimal balance between data size and specificity, ma
 
 ## Tier-Based Field Availability
 
+<!-- AUTOGEN:tier-matrix:cities START -->
 | Tier | Plans | Fields |
 |------|-------|--------|
 | **Basic** | Community, Starter, Legacy | `id`, `name` |
 | **Coordinates** | Supporter | All Basic **+** `state_id`, `state_code`, `country_id`, `country_code`, `latitude`, `longitude`, `timezone`, `population`, `type`, `level`, `parent_id`, `native` |
 | **Full** | Professional, Business | All Coordinates **+** `translations`, `wikiDataId` |
+<!-- AUTOGEN:tier-matrix:cities END -->
 
 See [Pricing](https://app.countrystatecity.in/pricing) for plan details.

--- a/api/endpoints/get-countries-by-subregion.mdx
+++ b/api/endpoints/get-countries-by-subregion.mdx
@@ -95,9 +95,12 @@ console.log(countries);
 
 This endpoint requires **Supporter+**, so the **Basic** tier never applies. Returned country fields match [Get Country Details](/api/endpoints/get-country-details):
 
+<!-- AUTOGEN:tier-matrix:countries START -->
 | Tier | Plans | Fields |
 |------|-------|--------|
-| **Coordinates** | Supporter | `id`, `name`, `iso2`, `iso3`, `phonecode`, `capital`, `currency`, `currency_name`, `currency_symbol`, `tld`, `nationality`, `native`, `emoji`, `emojiU`, `latitude`, `longitude`, `region`, `region_id`, `subregion`, `subregion_id`, `timezones`, `numeric_code`, `population`, `gdp`, `area_sq_km`, `postal_code_format`, `postal_code_regex` |
+| **Basic** | Community, Starter, Legacy | `id`, `name`, `iso2`, `iso3`, `phonecode`, `capital`, `currency`, `native`, `emoji`, `latitude`, `longitude`, `region`, `region_id`, `subregion`, `subregion_id`, `timezones` |
+| **Coordinates** | Supporter | All Basic **+** `numeric_code`, `currency_name`, `currency_symbol`, `tld`, `nationality`, `population`, `gdp`, `area_sq_km`, `postal_code_format`, `postal_code_regex`, `emojiU` |
 | **Full** | Professional, Business | All Coordinates **+** `translations`, `wikiDataId` |
+<!-- AUTOGEN:tier-matrix:countries END -->
 
 See [Pricing](https://app.countrystatecity.in/pricing) for plan details.

--- a/api/endpoints/get-country-details.mdx
+++ b/api/endpoints/get-country-details.mdx
@@ -401,10 +401,12 @@ Use this endpoint when you need detailed country information for user profiles, 
 
 ## Tier-Based Field Availability
 
+<!-- AUTOGEN:tier-matrix:countries START -->
 | Tier | Plans | Fields |
 |------|-------|--------|
 | **Basic** | Community, Starter, Legacy | `id`, `name`, `iso2`, `iso3`, `phonecode`, `capital`, `currency`, `native`, `emoji`, `latitude`, `longitude`, `region`, `region_id`, `subregion`, `subregion_id`, `timezones` |
 | **Coordinates** | Supporter | All Basic **+** `numeric_code`, `currency_name`, `currency_symbol`, `tld`, `nationality`, `population`, `gdp`, `area_sq_km`, `postal_code_format`, `postal_code_regex`, `emojiU` |
 | **Full** | Professional, Business | All Coordinates **+** `translations`, `wikiDataId` |
+<!-- AUTOGEN:tier-matrix:countries END -->
 
 See [Pricing](https://app.countrystatecity.in/pricing) for plan details.

--- a/api/endpoints/get-state-details.mdx
+++ b/api/endpoints/get-state-details.mdx
@@ -344,10 +344,12 @@ Use this endpoint when you need precise geographical coordinates or want to vali
 
 ## Tier-Based Field Availability
 
+<!-- AUTOGEN:tier-matrix:states START -->
 | Tier | Plans | Fields |
 |------|-------|--------|
 | **Basic** | Community, Starter, Legacy | `id`, `name`, `iso2`, `country_id`, `country_code`, `latitude`, `longitude`, `timezone` |
 | **Coordinates** | Supporter | All Basic **+** `fips_code`, `iso3166_2`, `type`, `level`, `parent_id`, `native`, `population` |
 | **Full** | Professional, Business | All Coordinates **+** `translations`, `wikiDataId` |
+<!-- AUTOGEN:tier-matrix:states END -->
 
 See [Pricing](https://app.countrystatecity.in/pricing) for plan details.

--- a/api/endpoints/get-states-by-country.mdx
+++ b/api/endpoints/get-states-by-country.mdx
@@ -345,10 +345,12 @@ Cache states by country as they rarely change. Use this endpoint instead of filt
 
 ## Tier-Based Field Availability
 
+<!-- AUTOGEN:tier-matrix:states START -->
 | Tier | Plans | Fields |
 |------|-------|--------|
 | **Basic** | Community, Starter, Legacy | `id`, `name`, `iso2`, `country_id`, `country_code`, `latitude`, `longitude`, `timezone` |
 | **Coordinates** | Supporter | All Basic **+** `fips_code`, `iso3166_2`, `type`, `level`, `parent_id`, `native`, `population` |
 | **Full** | Professional, Business | All Coordinates **+** `translations`, `wikiDataId` |
+<!-- AUTOGEN:tier-matrix:states END -->
 
 See [Pricing](https://app.countrystatecity.in/pricing) for plan details.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "sync-changelog": "node scripts/sync-changelog.js",
     "update-database-stats": "node scripts/update-database-stats.js",
+    "sync-tier-matrices": "node scripts/sync-tier-matrices.js",
+    "check-tier-matrices": "node scripts/sync-tier-matrices.js --check",
     "dev": "mintlify dev",
     "build": "mintlify build"
   },

--- a/scripts/sync-tier-matrices.js
+++ b/scripts/sync-tier-matrices.js
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+
+/**
+ * Tier Matrix Sync Script for Country State City Documentation
+ *
+ * Reads field-access mappings from csc-app's source-of-truth files and
+ * rewrites the marker-delimited "Tier-Based Field Availability" tables
+ * in api/endpoints/*.mdx, so docs stay in sync with the live filtering logic.
+ *
+ * Sources read (from csc-app/api/src):
+ *   services/dataAccessService.ts → FIELD_ACCESS (entity → level → fields)
+ *   config/pricingTiers.ts        → TIER_DEFAULTS (plan → dataAccessLevel)
+ *
+ * Markers expected in each MDX file:
+ *   <!-- AUTOGEN:tier-matrix:<entity> START -->
+ *   ...generated table...
+ *   <!-- AUTOGEN:tier-matrix:<entity> END -->
+ *
+ * Files without a marker are skipped, so docs that use inline tier annotations
+ * (regions, subregions) are unaffected.
+ *
+ * Usage:
+ *   node scripts/sync-tier-matrices.js              # rewrite in place
+ *   node scripts/sync-tier-matrices.js --check      # exit 1 if drift (for CI)
+ *   node scripts/sync-tier-matrices.js --source X   # explicit csc-app/api/src path
+ *
+ * Source path resolution (first match wins):
+ *   --source <path>       CLI arg
+ *   CSC_APP_SRC env var   Environment override
+ *   ../csc-app/api/src    Default (sibling checkout of csc-app)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MARKER_START = /<!--\s*AUTOGEN:tier-matrix:(\w+)\s+START\s*-->/;
+const MARKER_END = /<!--\s*AUTOGEN:tier-matrix:(\w+)\s+END\s*-->/;
+
+const KNOWN_TIERS = ['community', 'starter', 'supporter', 'professional', 'business', 'legacy'];
+const ACCESS_LEVELS = ['basic', 'coordinates', 'full'];
+
+/**
+ * Parse the FIELD_ACCESS object literal in dataAccessService.ts.
+ *
+ * The source structure is well-known:
+ *   const FIELD_ACCESS: ... = {
+ *     <entity>: {
+ *       basic: ['id', 'name', ...],
+ *       coordinates: [...],
+ *       full: [...],
+ *     },
+ *     ...
+ *   };
+ *
+ * We use a targeted regex rather than a TS parser to keep the script
+ * dependency-free. Brittle if the literal shape changes — paired with
+ * --check in CI, drift surfaces quickly.
+ */
+function parseFieldAccess(tsContent) {
+    const entityRegex = /(\w+):\s*\{\s*basic:\s*\[([^\]]+)\][\s,]*coordinates:\s*\[([^\]]+)\][\s,]*full:\s*\[([^\]]+)\][\s,]*\}/g;
+    const result = {};
+    for (const m of tsContent.matchAll(entityRegex)) {
+        const [, entity, basicRaw, coordRaw, fullRaw] = m;
+        result[entity] = {
+            basic: parseFieldList(basicRaw),
+            coordinates: parseFieldList(coordRaw),
+            full: parseFieldList(fullRaw),
+        };
+    }
+    if (Object.keys(result).length === 0) {
+        throw new Error('Could not parse any entities from FIELD_ACCESS — has dataAccessService.ts changed shape?');
+    }
+    return result;
+}
+
+/**
+ * Turn a raw array-literal body like "\n  'id',\n  'name',\n" into ['id', 'name'].
+ */
+function parseFieldList(raw) {
+    return raw
+        .split(',')
+        .map((s) => s.trim().replace(/^['"]|['"]$/g, ''))
+        .filter(Boolean);
+}
+
+/**
+ * Parse the TIER_DEFAULTS object in pricingTiers.ts to extract
+ * each plan's dataAccessLevel. We use [^{}] to stay inside one tier
+ * block at a time and not bleed into the nested features object.
+ */
+function parseTierDefaults(tsContent) {
+    const block = tsContent.match(/TIER_DEFAULTS[^=]*=\s*\{([\s\S]+?)\n\};/);
+    if (!block) {
+        throw new Error('Could not find TIER_DEFAULTS in pricingTiers.ts');
+    }
+    const tierRegex = /(\w+):\s*\{[^{}]*dataAccessLevel:\s*'(\w+)'/g;
+    const result = {};
+    for (const m of block[1].matchAll(tierRegex)) {
+        result[m[1]] = m[2];
+    }
+    if (Object.keys(result).length === 0) {
+        throw new Error('Parsed TIER_DEFAULTS block but found no dataAccessLevel entries');
+    }
+    return result;
+}
+
+/**
+ * Build the markdown table for one entity.
+ *
+ * Coordinates and Full rows use "All Basic **+** ..." / "All Coordinates **+** ..."
+ * to avoid repeating the lower-tier fields — matches the existing hand-written style.
+ */
+function generateMatrix(entity, fieldAccess, tierDefaults) {
+    const fields = fieldAccess[entity];
+    if (!fields) {
+        throw new Error(`Unknown entity '${entity}' — not present in FIELD_ACCESS`);
+    }
+
+    const plansByLevel = { basic: [], coordinates: [], full: [] };
+    for (const tier of KNOWN_TIERS) {
+        const level = tierDefaults[tier];
+        if (!level) continue;
+        if (!plansByLevel[level]) {
+            throw new Error(`Tier '${tier}' has unknown dataAccessLevel '${level}'`);
+        }
+        plansByLevel[level].push(capitalize(tier));
+    }
+
+    const fmt = (arr) => arr.map((f) => `\`${f}\``).join(', ');
+    const planList = (level) => plansByLevel[level].join(', ') || '—';
+
+    return [
+        '| Tier | Plans | Fields |',
+        '|------|-------|--------|',
+        `| **Basic** | ${planList('basic')} | ${fmt(fields.basic)} |`,
+        `| **Coordinates** | ${planList('coordinates')} | All Basic **+** ${fmt(fields.coordinates)} |`,
+        `| **Full** | ${planList('full')} | All Coordinates **+** ${fmt(fields.full)} |`,
+    ].join('\n');
+}
+
+function capitalize(s) {
+    return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+/**
+ * Walk a file line by line, rewriting any marker-delimited blocks.
+ * Returns { content, modified } so callers can decide whether to write.
+ */
+function rewriteFile(filePath, fieldAccess, tierDefaults) {
+    const original = fs.readFileSync(filePath, 'utf8');
+    const lines = original.split('\n');
+    const out = [];
+    let modified = false;
+
+    let i = 0;
+    while (i < lines.length) {
+        const startMatch = lines[i].match(MARKER_START);
+        if (!startMatch) {
+            out.push(lines[i]);
+            i++;
+            continue;
+        }
+
+        const entity = startMatch[1];
+        const startLine = lines[i];
+
+        let j = i + 1;
+        while (j < lines.length) {
+            const endMatch = lines[j].match(MARKER_END);
+            if (endMatch) {
+                if (endMatch[1] !== entity) {
+                    throw new Error(
+                        `${path.basename(filePath)}: marker mismatch — START is '${entity}' but END is '${endMatch[1]}'`
+                    );
+                }
+                break;
+            }
+            j++;
+        }
+        if (j === lines.length) {
+            throw new Error(`${path.basename(filePath)}: unclosed AUTOGEN marker for '${entity}'`);
+        }
+
+        const oldBlock = lines.slice(i + 1, j).join('\n');
+        const newBlock = generateMatrix(entity, fieldAccess, tierDefaults);
+
+        out.push(startLine);
+        out.push(newBlock);
+        out.push(lines[j]);
+
+        if (oldBlock.trim() !== newBlock.trim()) {
+            modified = true;
+        }
+        i = j + 1;
+    }
+
+    return { content: out.join('\n'), modified };
+}
+
+function resolveSourcePath(args) {
+    const sourceIdx = args.indexOf('--source');
+    if (sourceIdx >= 0) {
+        const next = args[sourceIdx + 1];
+        if (!next) {
+            throw new Error('--source flag requires a path argument');
+        }
+        return path.resolve(next);
+    }
+    if (process.env.CSC_APP_SRC) {
+        return path.resolve(process.env.CSC_APP_SRC);
+    }
+    return path.resolve(__dirname, '../../csc-app/api/src');
+}
+
+function main() {
+    const args = process.argv.slice(2);
+    const checkMode = args.includes('--check');
+    const sourcePath = resolveSourcePath(args);
+
+    const dataAccessFile = path.join(sourcePath, 'services/dataAccessService.ts');
+    const pricingFile = path.join(sourcePath, 'config/pricingTiers.ts');
+
+    for (const f of [dataAccessFile, pricingFile]) {
+        if (!fs.existsSync(f)) {
+            console.error(`❌ Cannot find source file: ${f}`);
+            console.error(`   Pass --source <csc-app/api/src> or set CSC_APP_SRC.`);
+            process.exit(1);
+        }
+    }
+
+    const fieldAccess = parseFieldAccess(fs.readFileSync(dataAccessFile, 'utf8'));
+    const tierDefaults = parseTierDefaults(fs.readFileSync(pricingFile, 'utf8'));
+
+    for (const level of ACCESS_LEVELS) {
+        const found = KNOWN_TIERS.some((t) => tierDefaults[t] === level);
+        if (!found) {
+            console.warn(`⚠️  No plan currently has access level '${level}' — generated rows will be empty.`);
+        }
+    }
+
+    const endpointsDir = path.join(__dirname, '../api/endpoints');
+    const files = fs.readdirSync(endpointsDir).filter((f) => f.endsWith('.mdx'));
+
+    let driftCount = 0;
+    let touched = 0;
+    const driftedFiles = [];
+
+    for (const file of files) {
+        const filePath = path.join(endpointsDir, file);
+        const original = fs.readFileSync(filePath, 'utf8');
+        if (!MARKER_START.test(original)) continue;
+
+        touched++;
+        const { content, modified } = rewriteFile(filePath, fieldAccess, tierDefaults);
+
+        if (modified) {
+            driftCount++;
+            driftedFiles.push(file);
+            if (checkMode) {
+                console.error(`⚠️  Drift detected: ${file}`);
+            } else {
+                fs.writeFileSync(filePath, content);
+                console.log(`✅ Updated: ${file}`);
+            }
+        }
+    }
+
+    if (touched === 0) {
+        console.warn('⚠️  No files contain AUTOGEN:tier-matrix markers — nothing to do.');
+        return;
+    }
+
+    if (checkMode) {
+        if (driftCount > 0) {
+            console.error(`\n❌ ${driftCount} file(s) have drift from source. Run \`npm run sync-tier-matrices\` to regenerate.`);
+            process.exit(1);
+        }
+        console.log(`✅ All ${touched} tier matrices are in sync.`);
+        return;
+    }
+
+    if (driftCount === 0) {
+        console.log(`✅ All ${touched} tier matrices already up to date.`);
+    } else {
+        console.log(`\n✅ Regenerated ${driftCount} of ${touched} file(s).`);
+    }
+}
+
+try {
+    main();
+} catch (err) {
+    console.error(`❌ ${err.message}`);
+    process.exit(1);
+}


### PR DESCRIPTION
## Summary

The "Tier-Based Field Availability" tables on each endpoint doc are now generated from csc-app's source-of-truth files (`services/dataAccessService.ts` for fields, `config/pricingTiers.ts` for plan→level mapping), instead of being hand-maintained.

### Why

The per-tier matrices duplicate state that lives in csc-app. After every change to which fields a plan returns, the docs had to be updated by hand — and if they drifted, customers got incorrect plan eligibility information.

### How

- **`scripts/sync-tier-matrices.js`** — Node script, zero dependencies, targeted regex parsing of the two well-shaped object literals (matches the style of `sync-changelog.js` / `update-database-stats.js`).
- **Marker delimiters** in MDX: `<!-- AUTOGEN:tier-matrix:<entity> START/END -->` wrap only the table. Surrounding heading, prose, and the "See Pricing" link stay manually editable, so each doc keeps its per-page framing.
- **Auto-discovery**: any MDX file with the marker is regenerated; docs without it (regions/subregions, which use inline tier annotations) are untouched.
- **Two npm scripts**:
  - `npm run sync-tier-matrices` — rewrite in place
  - `npm run check-tier-matrices` — `--check` mode, exit 1 on drift, suitable for CI
- **Source path resolution**: `--source <path>` arg → `CSC_APP_SRC` env → default `../csc-app/api/src` (sibling checkout).

### Validation

- Initial run regenerated **1 of 8** files. The other 7 docs were already byte-for-byte identical to the generator output — strongest possible evidence the parser is correct (the matrices I'd written by hand earlier matched what the script produces from the same sources).
- The one regenerated file (`get-countries-by-subregion.mdx`) had a deliberate hand-styled inconsistency: its Coordinates row concatenated basic + coordinates fields instead of using the "All Basic +" delta. The generator normalised it. The page-level Note above the matrix still says "Basic tier never applies" so the framing for this gated endpoint is unchanged.
- `npm run check-tier-matrices` returns exit 0 after the regeneration — idempotent.

## Files

- `scripts/sync-tier-matrices.js` (new, ~250 lines)
- `package.json` (2 new scripts)
- `CLAUDE.md` (workflow + marker conventions)
- 8 endpoint MDX files (wrapped existing tables with markers; one regenerated)

## Test plan

- [ ] `mint dev` and confirm every endpoint page still renders its Tier-Based Field Availability table correctly (HTML comments are invisible in Mintlify rendering)
- [ ] `npm run check-tier-matrices` returns exit 0
- [ ] Make a one-line change to `csc-app/api/src/services/dataAccessService.ts` locally (e.g. move a field from `coordinates` to `full`), run `npm run sync-tier-matrices` — verify the relevant doc(s) update and `--check` reports drift before regeneration
- [ ] Optional follow-up: wire `check-tier-matrices` into a GitHub Action that runs on every csc-app PR touching `dataAccessService.ts` or `pricingTiers.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)