### PR TITLE
docs: ISO lookup, phone dial code, timezone, fields & sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-05-20
+
+### Added
+
+- **Field Filtering & Sorting** cross-cutting guide — documents `?fields=` and `?sort=` syntax, tier gating (Supporter+), per-entity sortable fields, behaviour rules, and error responses
+- **ISO Code Endpoints** group: lookup country by alpha-2/alpha-3/numeric, lookup state by ISO 3166-2 subdivision code, convert between ISO formats
+- **Phone Endpoints** group: list dial codes with reverse lookup, get dial code by country, parse E.164 phone number into country + national parts
+- **Timezone Endpoints** group: timezone by country, state, and city — with DST-aware response (IANA name, abbreviation, std/DST offsets, current-DST flag)
+- Per-endpoint `?fields=` / `?sort=` callout on every geographic list and detail page (12 endpoints) linking back to the cross-cutting guide
+
+### Changed
+
+- Updated `llms.txt` to surface the new endpoint groups for AI assistants
+- Standardised the "Related Endpoints" footer pattern across the new endpoint pages
+
 ## [1.1.0] - 2026-04-03
 
 ### Added

--- a/api/endpoints/convert-iso-code.mdx
+++ b/api/endpoints/convert-iso-code.mdx
@@ -1,0 +1,169 @@
+---
+title: "Convert ISO Code"
+api: "GET https://api.countrystatecity.in/v1/iso/country/convert"
+authMethod: "key"
+description: "Translate a country code between ISO 3166-1 alpha-2, alpha-3, and numeric formats"
+---
+
+Convert a country code between the three ISO 3166-1 formats in a single call:
+
+- alpha-2 ↔ alpha-3 (e.g. `US` ↔ `USA`)
+- alpha-2 ↔ numeric (e.g. `US` ↔ `840`)
+- alpha-3 ↔ numeric (e.g. `USA` ↔ `840`)
+
+Useful when an upstream system gives you one format and a downstream service expects another.
+
+<Note>**Availability:** Starter plan and above. Returns `403` on Community plan.</Note>
+
+<Info>
+**Cache reuse:** Conversions share the same cache slot as [`/v1/iso/country`](/api/endpoints/lookup-country-by-iso). A previous `?iso2=US` lookup serves any `?from=iso2&value=US&to=...` conversion without a fresh database hit. The target column is extracted after the cache read, so different `to` values reuse the same slot.
+
+Numeric inputs `4` and `004` resolve to the same cache slot.
+</Info>
+
+## Authentication
+
+<ParamField header="X-CSCAPI-KEY" type="string" required>
+  Your API key for authentication
+</ParamField>
+
+## Query Parameters
+
+<ParamField query="from" type="string" required>
+  Source format. One of `iso2`, `iso3`, `numeric`.
+</ParamField>
+
+<ParamField query="to" type="string" required>
+  Target format. One of `iso2`, `iso3`, `numeric`. Must differ from `from`.
+</ParamField>
+
+<ParamField query="value" type="string" required>
+  The code to convert. Must match the format named in `from`:
+
+  - `from=iso2` → 2 letters (e.g. `US`)
+  - `from=iso3` → 3 letters (e.g. `USA`)
+  - `from=numeric` → 1–3 digits, non-zero (e.g. `840` or `4`)
+
+  Letter codes are auto-uppercased.
+</ParamField>
+
+## Response
+
+<ResponseField name="from" type="string">
+  Echo of the source format you requested.
+</ResponseField>
+
+<ResponseField name="to" type="string">
+  Echo of the target format you requested.
+</ResponseField>
+
+<ResponseField name="input" type="string">
+  Echo of the `value` you sent — useful for matching responses to requests when batching.
+</ResponseField>
+
+<ResponseField name="result" type="string">
+  The converted code. For `to=numeric`, returned zero-padded to 3 digits (e.g. `"840"`).
+</ResponseField>
+
+<RequestExample>
+```bash cURL (alpha-2 → alpha-3)
+curl -X GET 'https://api.countrystatecity.in/v1/iso/country/convert?from=iso2&to=iso3&value=US' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```bash cURL (alpha-3 → numeric)
+curl -X GET 'https://api.countrystatecity.in/v1/iso/country/convert?from=iso3&to=numeric&value=IND' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```bash cURL (numeric → alpha-2)
+curl -X GET 'https://api.countrystatecity.in/v1/iso/country/convert?from=numeric&to=iso2&value=840' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```javascript JavaScript
+const params = new URLSearchParams({ from: 'iso2', to: 'iso3', value: 'DE' });
+const response = await fetch(
+  `https://api.countrystatecity.in/v1/iso/country/convert?${params}`,
+  { headers: { 'X-CSCAPI-KEY': 'YOUR_API_KEY' } }
+);
+
+const { result } = await response.json();
+console.log(result); // "DEU"
+```
+
+```python Python
+import requests
+
+response = requests.get(
+  'https://api.countrystatecity.in/v1/iso/country/convert',
+  params={'from': 'iso2', 'to': 'numeric', 'value': 'JP'},
+  headers={'X-CSCAPI-KEY': 'YOUR_API_KEY'}
+)
+
+print(response.json()['result'])  # "392"
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200 - Success (alpha-2 → alpha-3)
+{
+  "from": "iso2",
+  "to": "iso3",
+  "input": "US",
+  "result": "USA"
+}
+```
+
+```json 200 - Success (alpha-3 → numeric)
+{
+  "from": "iso3",
+  "to": "numeric",
+  "input": "IND",
+  "result": "356"
+}
+```
+
+```json 400 - Same from/to
+{
+  "error": "Invalid query parameters: from and to must be different"
+}
+```
+
+```json 400 - Value doesn't match from
+{
+  "error": "Invalid query parameters: value does not match the format required by from"
+}
+```
+
+```json 400 - Invalid format name
+{
+  "error": "Invalid query parameters: from: must be one of: iso2, iso3, numeric"
+}
+```
+
+```json 403 - Feature Restricted
+{
+  "error": "This feature is not available on your current plan.",
+  "feature": "isoLookup",
+  "upgradeUrl": "https://app.countrystatecity.in/pricing"
+}
+```
+
+```json 404 - Source code unknown
+{
+  "error": "Country not found for the given code"
+}
+```
+
+```json 404 - Target column null
+{
+  "error": "No iso3 code available for this country"
+}
+```
+</ResponseExample>
+
+## Related Endpoints
+
+- [Lookup Country by ISO Code](/api/endpoints/lookup-country-by-iso) — return the full country record instead of just the converted code
+- [Lookup State by ISO Code](/api/endpoints/lookup-state-by-iso) — ISO 3166-2 subdivision lookup

--- a/api/endpoints/get-all-countries.mdx
+++ b/api/endpoints/get-all-countries.mdx
@@ -9,6 +9,10 @@ Retrieve a complete list of all countries with basic information including ISO c
 
 <Note>**Availability:** All plans (Community and above). The fields returned vary by tier — see **Tier-Based Field Availability** below.</Note>
 
+<Tip>
+**Trim and order results:** Add `?fields=` to limit columns returned, or `?sort=` to order the list. Both are available on **Supporter+** plans. See the [Field Filtering & Sorting](/api/field-filtering-and-sorting) guide for syntax and per-entity sortable fields.
+</Tip>
+
 ## Authentication
 
 <ParamField header="X-CSCAPI-KEY" type="string" required>

--- a/api/endpoints/get-all-regions.mdx
+++ b/api/endpoints/get-all-regions.mdx
@@ -9,6 +9,10 @@ Retrieve all geographic regions (Africa, Americas, Asia, Europe, Oceania, Polar)
 
 <Note>**Availability:** Supporter plan and above. Returns `403` on lower tiers.</Note>
 
+<Tip>
+**Trim and order results:** Add `?fields=` to limit columns returned, or `?sort=` to order the list. Both are available on **Supporter+** plans. See the [Field Filtering & Sorting](/api/field-filtering-and-sorting) guide for syntax and per-entity sortable fields.
+</Tip>
+
 ## Authentication
 
 <ParamField header="X-CSCAPI-KEY" type="string" required>

--- a/api/endpoints/get-all-states.mdx
+++ b/api/endpoints/get-all-states.mdx
@@ -9,6 +9,10 @@ Retrieve a complete list of all states, provinces, regions, and territories from
 
 <Note>**Availability:** Supporter plan and above. Calling `/states` without filtering by country (`bulkStates`) is gated to Supporter+. Community/Starter users must call `/countries/{iso2}/states` instead. The fields returned also vary by tier — see **Tier-Based Field Availability** below.</Note>
 
+<Tip>
+**Trim and order results:** Add `?fields=` to limit columns returned, or `?sort=` to order the list. Both are available on **Supporter+** plans. See the [Field Filtering & Sorting](/api/field-filtering-and-sorting) guide for syntax and per-entity sortable fields.
+</Tip>
+
 ## Authentication
 
 <ParamField header="X-CSCAPI-KEY" type="string" required>

--- a/api/endpoints/get-cities-by-country.mdx
+++ b/api/endpoints/get-cities-by-country.mdx
@@ -13,6 +13,10 @@ Retrieve all cities within a specific country using the country's ISO2 code. Thi
   ISO2 code of the country (e.g., "IN" for India, "US" for United States)
 </ParamField>
 
+<Tip>
+**Trim and order results:** Add `?fields=` to limit columns returned, or `?sort=` to order the list. Both are available on **Supporter+** plans. See the [Field Filtering & Sorting](/api/field-filtering-and-sorting) guide for syntax and per-entity sortable fields.
+</Tip>
+
 ## Authentication
 
 <ParamField header="X-CSCAPI-KEY" type="string" required>

--- a/api/endpoints/get-cities-by-state.mdx
+++ b/api/endpoints/get-cities-by-state.mdx
@@ -19,6 +19,10 @@ Retrieve all cities within a specific state or province using both the country's
   ISO2 code of the state/province (e.g., "MH" for Maharashtra, "CA" for California)
 </ParamField>
 
+<Tip>
+**Trim and order results:** Add `?fields=` to limit columns returned, or `?sort=` to order the list. Both are available on **Supporter+** plans. See the [Field Filtering & Sorting](/api/field-filtering-and-sorting) guide for syntax and per-entity sortable fields.
+</Tip>
+
 ## Authentication
 
 <ParamField header="X-CSCAPI-KEY" type="string" required>

--- a/api/endpoints/get-countries-by-subregion.mdx
+++ b/api/endpoints/get-countries-by-subregion.mdx
@@ -9,6 +9,10 @@ Retrieve all countries within a subregion. For example, subregion "Southern Asia
 
 <Note>**Availability:** Supporter plan and above.</Note>
 
+<Tip>
+**Trim and order results:** Add `?fields=` to limit columns returned, or `?sort=` to order the list. Both are available on **Supporter+** plans. See the [Field Filtering & Sorting](/api/field-filtering-and-sorting) guide for syntax and per-entity sortable fields.
+</Tip>
+
 ## Authentication
 
 <ParamField header="X-CSCAPI-KEY" type="string" required>

--- a/api/endpoints/get-country-details.mdx
+++ b/api/endpoints/get-country-details.mdx
@@ -15,6 +15,10 @@ Retrieve detailed information for a specific country using its ISO2 code, includ
   ISO2 code of the country (e.g., "IN" for India, "US" for United States)
 </ParamField>
 
+<Tip>
+**Trim response columns:** Add `?fields=name,iso2,...` to receive only the columns you need. Available on **Supporter+** plans. See the [Field Filtering & Sorting](/api/field-filtering-and-sorting) guide for syntax.
+</Tip>
+
 ## Authentication
 
 <ParamField header="X-CSCAPI-KEY" type="string" required>

--- a/api/endpoints/get-dial-code-by-country.mdx
+++ b/api/endpoints/get-dial-code-by-country.mdx
@@ -1,0 +1,136 @@
+---
+title: "Get Dial Code by Country"
+api: "GET https://api.countrystatecity.in/v1/phone/{ciso}"
+authMethod: "key"
+description: "Retrieve the international dial code for a single country by ISO2, ISO3, or numeric ID"
+---
+
+Get the dial code for one country. The path parameter accepts **three forms** — the same identifier flexibility as the rest of the geographic API:
+
+- ISO 3166-1 alpha-2 (e.g. `US`, `IN`)
+- ISO 3166-1 alpha-3 (e.g. `USA`, `IND`)
+- Numeric CSC country ID (e.g. `233`)
+
+<Note>**Availability:** Supporter plan and above. Returns `403` on lower tiers.</Note>
+
+<Info>Responses are cached server-side for 24 hours. Numeric IDs `1` and `001` resolve to the same cache slot; letter codes are case-insensitive.</Info>
+
+## Authentication
+
+<ParamField header="X-CSCAPI-KEY" type="string" required>
+  Your API key for authentication
+</ParamField>
+
+## Path Parameters
+
+<ParamField path="ciso" type="string" required>
+  ISO2 code, ISO3 code, or numeric country ID. Case-insensitive for ISO codes.
+</ParamField>
+
+## Response
+
+A single phone entry (object, **not** an array — unlike the list endpoint).
+
+<ResponseField name="country" type="string">
+  ISO 3166-1 alpha-2 code of the country (e.g. `"US"`). Convenience field equal to `iso2`.
+</ResponseField>
+
+<ResponseField name="dial_code" type="string">
+  Dial code with leading `+` (e.g. `"+91"`).
+</ResponseField>
+
+<ResponseField name="area_code" type="string">
+  Present only for NANP entries with a fixed area-code prefix in the underlying data (e.g. `"246"` for Barbados). Omitted when not applicable — do not assume the field exists.
+</ResponseField>
+
+<ResponseField name="iso2" type="string">
+  ISO 3166-1 alpha-2 code.
+</ResponseField>
+
+<ResponseField name="iso3" type="string">
+  ISO 3166-1 alpha-3 code.
+</ResponseField>
+
+<RequestExample>
+```bash cURL (ISO2)
+curl -X GET 'https://api.countrystatecity.in/v1/phone/US' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```bash cURL (ISO3)
+curl -X GET 'https://api.countrystatecity.in/v1/phone/IND' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```bash cURL (numeric ID)
+curl -X GET 'https://api.countrystatecity.in/v1/phone/233' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```javascript JavaScript
+const response = await fetch('https://api.countrystatecity.in/v1/phone/US', {
+  headers: { 'X-CSCAPI-KEY': 'YOUR_API_KEY' }
+});
+
+const { dial_code } = await response.json();
+console.log(dial_code); // "+1"
+```
+
+```python Python
+import requests
+
+response = requests.get(
+  'https://api.countrystatecity.in/v1/phone/IN',
+  headers={'X-CSCAPI-KEY': 'YOUR_API_KEY'}
+)
+
+print(response.json()['dial_code'])  # "+91"
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200 - Standard country
+{
+  "country": "IN",
+  "dial_code": "+91",
+  "iso2": "IN",
+  "iso3": "IND"
+}
+```
+
+```json 200 - NANP entry (with area_code)
+{
+  "country": "BB",
+  "dial_code": "+1",
+  "area_code": "246",
+  "iso2": "BB",
+  "iso3": "BRB"
+}
+```
+
+```json 403 - Feature Restricted
+{
+  "error": "This feature is not available on your current plan.",
+  "feature": "phoneDialCode",
+  "upgradeUrl": "https://app.countrystatecity.in/pricing"
+}
+```
+
+```json 404 - Country Not Found
+{
+  "error": "Country not found."
+}
+```
+
+```json 404 - No Dial Code on Record
+{
+  "error": "No dial code available for this country."
+}
+```
+</ResponseExample>
+
+## Related Endpoints
+
+- [List Dial Codes](/api/endpoints/list-dial-codes) — every country, plus reverse lookup by dial code
+- [Parse Phone Number](/api/endpoints/parse-phone-number) — given an E.164 number, identify the country
+- [Get Country Details](/api/endpoints/get-country-details) — full country record, including `phonecode`

--- a/api/endpoints/get-region-details.mdx
+++ b/api/endpoints/get-region-details.mdx
@@ -9,6 +9,10 @@ Retrieve detailed information for a single geographic region (e.g., Africa, Amer
 
 <Note>**Availability:** Supporter plan and above. Returns `403` on lower tiers.</Note>
 
+<Tip>
+**Trim response columns:** Add `?fields=name,iso2,...` to receive only the columns you need. Available on **Supporter+** plans. See the [Field Filtering & Sorting](/api/field-filtering-and-sorting) guide for syntax.
+</Tip>
+
 ## Authentication
 
 <ParamField header="X-CSCAPI-KEY" type="string" required>

--- a/api/endpoints/get-state-details.mdx
+++ b/api/endpoints/get-state-details.mdx
@@ -19,6 +19,10 @@ Retrieve detailed information for a specific state or province using the country
   ISO2 code of the state/province (e.g., "MH" for Maharashtra, "CA" for California)
 </ParamField>
 
+<Tip>
+**Trim response columns:** Add `?fields=name,iso2,...` to receive only the columns you need. Available on **Supporter+** plans. See the [Field Filtering & Sorting](/api/field-filtering-and-sorting) guide for syntax.
+</Tip>
+
 ## Authentication
 
 <ParamField header="X-CSCAPI-KEY" type="string" required>

--- a/api/endpoints/get-states-by-country.mdx
+++ b/api/endpoints/get-states-by-country.mdx
@@ -15,6 +15,10 @@ Retrieve all states, provinces, regions, and territories for a specific country 
   ISO2 code of the country (e.g., "IN" for India, "US" for United States)
 </ParamField>
 
+<Tip>
+**Trim and order results:** Add `?fields=` to limit columns returned, or `?sort=` to order the list. Both are available on **Supporter+** plans. See the [Field Filtering & Sorting](/api/field-filtering-and-sorting) guide for syntax and per-entity sortable fields.
+</Tip>
+
 ## Authentication
 
 <ParamField header="X-CSCAPI-KEY" type="string" required>

--- a/api/endpoints/get-subregion-details.mdx
+++ b/api/endpoints/get-subregion-details.mdx
@@ -9,6 +9,10 @@ Retrieve detailed information for a single subregion (e.g., Southern Asia, Weste
 
 <Note>**Availability:** Supporter plan and above. Returns `403` on lower tiers.</Note>
 
+<Tip>
+**Trim response columns:** Add `?fields=name,iso2,...` to receive only the columns you need. Available on **Supporter+** plans. See the [Field Filtering & Sorting](/api/field-filtering-and-sorting) guide for syntax.
+</Tip>
+
 ## Authentication
 
 <ParamField header="X-CSCAPI-KEY" type="string" required>

--- a/api/endpoints/get-subregions-by-region.mdx
+++ b/api/endpoints/get-subregions-by-region.mdx
@@ -9,6 +9,10 @@ Retrieve all subregions belonging to a specific region. For example, region "Asi
 
 <Note>**Availability:** Supporter plan and above.</Note>
 
+<Tip>
+**Trim and order results:** Add `?fields=` to limit columns returned, or `?sort=` to order the list. Both are available on **Supporter+** plans. See the [Field Filtering & Sorting](/api/field-filtering-and-sorting) guide for syntax and per-entity sortable fields.
+</Tip>
+
 ## Authentication
 
 <ParamField header="X-CSCAPI-KEY" type="string" required>

--- a/api/endpoints/get-timezone-by-city.mdx
+++ b/api/endpoints/get-timezone-by-city.mdx
@@ -1,0 +1,126 @@
+---
+title: "Get Timezone by City"
+api: "GET https://api.countrystatecity.in/v1/timezone/{ciso}/{siso}/{city_id}"
+authMethod: "key"
+description: "Retrieve the timezone for a specific city"
+---
+
+Get the timezone for a specific city. The country and state codes in the path are not redundant — they're enforced server-side as an **ownership check**: a city ID is only resolved if it actually belongs to the given state inside the given country.
+
+This prevents "city-ID spoofing" — a caller can't learn the timezone of an arbitrary city by trying its ID under a different country/state pair.
+
+<Note>**Availability:** All plans (Community and above). Only an API key is required.</Note>
+
+<Info>Responses are cached server-side for 24 hours. The cache key includes country, state, **and** city ID, so the ownership check holds on cache HIT — a city ID looked up under one (ciso, siso) pair won't satisfy a request under a different pair.</Info>
+
+## Authentication
+
+<ParamField header="X-CSCAPI-KEY" type="string" required>
+  Your API key for authentication
+</ParamField>
+
+## Path Parameters
+
+<ParamField path="ciso" type="string" required>
+  Country code: ISO 3166-1 alpha-2 (`US`), alpha-3 (`USA`), or numeric CSC ID. Case-insensitive.
+</ParamField>
+
+<ParamField path="siso" type="string" required>
+  State/province code (e.g. `CA` for California). Case-insensitive.
+</ParamField>
+
+<ParamField path="city_id" type="integer" required>
+  Numeric CSC city ID. Get this from `/v1/countries/:ciso/states/:siso/cities` or `/v1/cities`.
+</ParamField>
+
+## Response
+
+Same shape as the country and state timezone endpoints:
+
+<ResponseField name="iana" type="string">
+  Canonical IANA timezone name (e.g. `"America/Los_Angeles"`).
+</ResponseField>
+
+<ResponseField name="abbreviation" type="string">
+  Locale-aware short name at request time.
+</ResponseField>
+
+<ResponseField name="offset_utc" type="string">
+  Standard UTC offset in `±HH:MM` form.
+</ResponseField>
+
+<ResponseField name="dst_offset_utc" type="string">
+  DST UTC offset in `±HH:MM` form.
+</ResponseField>
+
+<ResponseField name="is_dst_now" type="boolean">
+  Whether DST is in effect at request time.
+</ResponseField>
+
+<RequestExample>
+```bash cURL (San Francisco, CA)
+curl -X GET 'https://api.countrystatecity.in/v1/timezone/US/CA/24295' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```bash cURL (Mumbai, IN-MH)
+curl -X GET 'https://api.countrystatecity.in/v1/timezone/IN/MH/57614' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```javascript JavaScript
+const response = await fetch(
+  'https://api.countrystatecity.in/v1/timezone/US/CA/24295',  // San Francisco
+  { headers: { 'X-CSCAPI-KEY': 'YOUR_API_KEY' } }
+);
+
+const tz = await response.json();
+const localNow = new Date().toLocaleString('en-US', { timeZone: tz.iana });
+console.log(`Current local time: ${localNow}`);
+```
+
+```python Python
+import requests
+
+response = requests.get(
+  'https://api.countrystatecity.in/v1/timezone/US/NY/124394',  # New York City
+  headers={'X-CSCAPI-KEY': 'YOUR_API_KEY'}
+)
+
+print(response.json()['iana'])  # "America/New_York"
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200 - San Francisco (DST in summer)
+{
+  "iana": "America/Los_Angeles",
+  "abbreviation": "PDT",
+  "offset_utc": "-08:00",
+  "dst_offset_utc": "-07:00",
+  "is_dst_now": true
+}
+```
+
+```json 404 - City not in this country/state
+{
+  "error": "City not found."
+}
+```
+
+```json 404 - No timezone on record
+{
+  "error": "No timezone data available for this city."
+}
+```
+</ResponseExample>
+
+## Related Endpoints
+
+- [Get Timezone by Country](/api/endpoints/get-timezone-by-country) — country-level (uses the capital's timezone)
+- [Get Timezone by State](/api/endpoints/get-timezone-by-state) — state-level precision
+- [Get Cities by State](/api/endpoints/get-cities-by-state) — list cities to find the right city ID
+
+## Notes on `city_id`
+
+The `city_id` is the same numeric ID returned by all list endpoints (`/v1/countries/:ciso/states/:siso/cities`, `/v1/cities`, etc.). If you stored a city ID in your own database, this endpoint is the canonical way to look up its timezone without re-fetching the full city record.

--- a/api/endpoints/get-timezone-by-country.mdx
+++ b/api/endpoints/get-timezone-by-country.mdx
@@ -1,0 +1,144 @@
+---
+title: "Get Timezone by Country"
+api: "GET https://api.countrystatecity.in/v1/timezone/{ciso}"
+authMethod: "key"
+description: "Retrieve the canonical timezone for a country including current DST state"
+---
+
+Return the canonical IANA timezone for a country, plus its standard and DST UTC offsets and whether the country is observing DST at request time.
+
+Resolution order:
+
+1. The capital city's timezone — most countries with multiple zones use this as the canonical default.
+2. The first entry in the country's `timezones` JSON column — fallback when no capital-city match exists.
+
+<Note>**Availability:** All plans (Community and above). Only an API key is required.</Note>
+
+<Info>Responses are cached server-side for 24 hours.</Info>
+
+<Warning>
+**Known DST sampling limitation:** standard and DST offsets are determined by sampling Jan 1 and Jul 1 of the current year, which is correct for almost every populated IANA zone. A small number of zones with non-standard DST windows (most notably `Africa/Casablanca` with Ramadan-based transitions) can report incorrect `offset_utc` / `dst_offset_utc` / `is_dst_now` values during their actual DST window. Use a dedicated timezone library if you need exact DST behaviour for those edge cases.
+</Warning>
+
+## Authentication
+
+<ParamField header="X-CSCAPI-KEY" type="string" required>
+  Your API key for authentication
+</ParamField>
+
+## Path Parameters
+
+<ParamField path="ciso" type="string" required>
+  ISO 3166-1 alpha-2 code (e.g. `US`), alpha-3 code (e.g. `USA`), or numeric CSC country ID (e.g. `233`). Case-insensitive for ISO codes.
+</ParamField>
+
+## Response
+
+<ResponseField name="iana" type="string">
+  Canonical IANA timezone name (e.g. `"America/New_York"`). Use this with any standards-compliant date/time library — JavaScript `Intl`, Python `zoneinfo`, Java `ZoneId`, etc.
+</ResponseField>
+
+<ResponseField name="abbreviation" type="string">
+  Locale-aware short name at request time (e.g. `"EST"` in winter, `"EDT"` in summer). Display-only — not stable enough to use as an identifier.
+</ResponseField>
+
+<ResponseField name="offset_utc" type="string">
+  Standard (non-DST) UTC offset in `±HH:MM` form (e.g. `"-05:00"` for US Eastern).
+</ResponseField>
+
+<ResponseField name="dst_offset_utc" type="string">
+  DST UTC offset in `±HH:MM` form (e.g. `"-04:00"` for US Eastern Daylight). Equal to `offset_utc` for zones that don't observe DST.
+</ResponseField>
+
+<ResponseField name="is_dst_now" type="boolean">
+  Whether DST is in effect for this zone at request time. `false` when the zone doesn't observe DST.
+</ResponseField>
+
+<RequestExample>
+```bash cURL (ISO2)
+curl -X GET 'https://api.countrystatecity.in/v1/timezone/US' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```bash cURL (ISO3)
+curl -X GET 'https://api.countrystatecity.in/v1/timezone/IND' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```bash cURL (numeric ID)
+curl -X GET 'https://api.countrystatecity.in/v1/timezone/233' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```javascript JavaScript
+const response = await fetch('https://api.countrystatecity.in/v1/timezone/US', {
+  headers: { 'X-CSCAPI-KEY': 'YOUR_API_KEY' }
+});
+
+const tz = await response.json();
+// Format current time in that zone
+const local = new Date().toLocaleString('en-US', { timeZone: tz.iana });
+console.log(`${tz.iana} | ${local} | DST: ${tz.is_dst_now}`);
+```
+
+```python Python
+import requests
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+response = requests.get(
+  'https://api.countrystatecity.in/v1/timezone/IN',
+  headers={'X-CSCAPI-KEY': 'YOUR_API_KEY'}
+)
+
+tz = response.json()
+now_local = datetime.now(ZoneInfo(tz['iana']))
+print(f"{tz['iana']} ({tz['abbreviation']}) — {now_local}")
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200 - DST-observing country (in summer)
+{
+  "iana": "America/New_York",
+  "abbreviation": "EDT",
+  "offset_utc": "-05:00",
+  "dst_offset_utc": "-04:00",
+  "is_dst_now": true
+}
+```
+
+```json 200 - Non-DST country
+{
+  "iana": "Asia/Kolkata",
+  "abbreviation": "GMT+5:30",
+  "offset_utc": "+05:30",
+  "dst_offset_utc": "+05:30",
+  "is_dst_now": false
+}
+```
+
+```json 401 - Unauthorized
+{
+  "error": "Unauthorized. You shouldn't be here."
+}
+```
+
+```json 404 - Country Not Found
+{
+  "error": "Country not found."
+}
+```
+
+```json 404 - No Timezone Data
+{
+  "error": "No timezone data available for this country."
+}
+```
+</ResponseExample>
+
+## Related Endpoints
+
+- [Get Timezone by State](/api/endpoints/get-timezone-by-state) — finer-grained timezone for federations / countries with multiple zones (US, Canada, Russia, Australia, etc.)
+- [Get Timezone by City](/api/endpoints/get-timezone-by-city) — per-city precision
+- [Get Country Details](/api/endpoints/get-country-details) — includes the raw `timezones` JSON column

--- a/api/endpoints/get-timezone-by-state.mdx
+++ b/api/endpoints/get-timezone-by-state.mdx
@@ -1,0 +1,132 @@
+---
+title: "Get Timezone by State"
+api: "GET https://api.countrystatecity.in/v1/timezone/{ciso}/{siso}"
+authMethod: "key"
+description: "Retrieve the timezone for a specific state or province"
+---
+
+Get the timezone for a state/province within a country. Useful for federations or countries that span multiple zones — US states, Canadian provinces, Russian federal subjects, Australian states, etc.
+
+<Note>**Availability:** All plans (Community and above). Only an API key is required.</Note>
+
+<Info>Responses are cached server-side for 24 hours. The cache key includes both the country and state codes, so cross-country state-code collisions never cause cache poisoning.</Info>
+
+## Authentication
+
+<ParamField header="X-CSCAPI-KEY" type="string" required>
+  Your API key for authentication
+</ParamField>
+
+## Path Parameters
+
+<ParamField path="ciso" type="string" required>
+  Country code: ISO 3166-1 alpha-2 (`US`), alpha-3 (`USA`), or numeric CSC ID. Case-insensitive.
+</ParamField>
+
+<ParamField path="siso" type="string" required>
+  State/province code in the country's local subdivision system (e.g. `CA` for California within `US-CA`). Case-insensitive.
+</ParamField>
+
+## Response
+
+Identical shape to [`/v1/timezone/:ciso`](/api/endpoints/get-timezone-by-country):
+
+<ResponseField name="iana" type="string">
+  Canonical IANA timezone name (e.g. `"America/Los_Angeles"`).
+</ResponseField>
+
+<ResponseField name="abbreviation" type="string">
+  Locale-aware short name at request time (e.g. `"PST"` / `"PDT"`).
+</ResponseField>
+
+<ResponseField name="offset_utc" type="string">
+  Standard UTC offset in `±HH:MM` form (e.g. `"-08:00"`).
+</ResponseField>
+
+<ResponseField name="dst_offset_utc" type="string">
+  DST UTC offset in `±HH:MM` form (e.g. `"-07:00"`). Equal to `offset_utc` for zones that don't observe DST.
+</ResponseField>
+
+<ResponseField name="is_dst_now" type="boolean">
+  Whether DST is in effect at request time.
+</ResponseField>
+
+<RequestExample>
+```bash cURL (California)
+curl -X GET 'https://api.countrystatecity.in/v1/timezone/US/CA' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```bash cURL (Maharashtra, India)
+curl -X GET 'https://api.countrystatecity.in/v1/timezone/IN/MH' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```bash cURL (Bavaria, Germany — ISO3 country)
+curl -X GET 'https://api.countrystatecity.in/v1/timezone/DEU/BY' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```javascript JavaScript
+const response = await fetch(
+  'https://api.countrystatecity.in/v1/timezone/US/NY',
+  { headers: { 'X-CSCAPI-KEY': 'YOUR_API_KEY' } }
+);
+
+const tz = await response.json();
+console.log(`${tz.iana} | DST in effect: ${tz.is_dst_now}`);
+```
+
+```python Python
+import requests
+
+response = requests.get(
+  'https://api.countrystatecity.in/v1/timezone/US/HI',  # Hawaii — no DST
+  headers={'X-CSCAPI-KEY': 'YOUR_API_KEY'}
+)
+
+print(response.json())
+# {"iana": "Pacific/Honolulu", "abbreviation": "HST", "offset_utc": "-10:00",
+#  "dst_offset_utc": "-10:00", "is_dst_now": false}
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200 - California (DST in summer)
+{
+  "iana": "America/Los_Angeles",
+  "abbreviation": "PDT",
+  "offset_utc": "-08:00",
+  "dst_offset_utc": "-07:00",
+  "is_dst_now": true
+}
+```
+
+```json 200 - Hawaii (no DST)
+{
+  "iana": "Pacific/Honolulu",
+  "abbreviation": "HST",
+  "offset_utc": "-10:00",
+  "dst_offset_utc": "-10:00",
+  "is_dst_now": false
+}
+```
+
+```json 404 - State Not Found
+{
+  "error": "State not found."
+}
+```
+
+```json 404 - No Timezone Data
+{
+  "error": "No timezone data available for this state."
+}
+```
+</ResponseExample>
+
+## Related Endpoints
+
+- [Get Timezone by Country](/api/endpoints/get-timezone-by-country) — country-level resolution (uses the capital's timezone)
+- [Get Timezone by City](/api/endpoints/get-timezone-by-city) — per-city precision
+- [Get State Details](/api/endpoints/get-state-details) — full state record including the raw `timezone` field

--- a/api/endpoints/list-dial-codes.mdx
+++ b/api/endpoints/list-dial-codes.mdx
@@ -1,0 +1,141 @@
+---
+title: "List Dial Codes"
+api: "GET https://api.countrystatecity.in/v1/phone"
+authMethod: "key"
+description: "List every country's international dial code, with optional reverse lookup by dial code"
+---
+
+Return every country's international dial code in one call, or do the reverse — find every country that shares a given dial code (useful for NANP `+1` countries like the US and Canada).
+
+Dial codes follow ITU-T E.164 and are returned with a leading `+`. For NANP countries with an area-code prefix in the underlying data (e.g. Barbados as `+1-246`), the area code is returned as a separate `area_code` field.
+
+<Note>**Availability:** Supporter plan and above. Returns `403` on lower tiers.</Note>
+
+<Info>Responses are cached server-side for 24 hours. Equivalent dial-code inputs (`+91`, `91`, `091`, `0091`) all resolve to the same cache slot.</Info>
+
+## Authentication
+
+<ParamField header="X-CSCAPI-KEY" type="string" required>
+  Your API key for authentication
+</ParamField>
+
+## Query Parameters
+
+<ParamField query="code" type="string">
+  Optional. Restrict the response to countries with the given dial code. Accepts:
+
+  - With or without leading `+` (`+91` or `91`)
+  - 1–4 digits
+  - Leading zeros are stripped (so `01`, `001`, `1` all match `+1`)
+  - NANP area-code variants — `?code=+1` returns the US, Canada, and every NANP territory in one response
+
+  Without this parameter, every country with a dial code is returned (sorted by ISO2 code).
+</ParamField>
+
+## Response
+
+The response is **an array of phone entries**, even when the result is a single country.
+
+<ResponseField name="country" type="string">
+  ISO 3166-1 alpha-2 code of the country (e.g. `"US"`). Convenience field equal to `iso2`.
+</ResponseField>
+
+<ResponseField name="dial_code" type="string">
+  Dial code with leading `+` (e.g. `"+91"`).
+</ResponseField>
+
+<ResponseField name="area_code" type="string">
+  Present only for NANP entries with a fixed area-code prefix in the underlying data (e.g. `"246"` for Barbados). Omitted when not applicable — do not assume the field exists.
+</ResponseField>
+
+<ResponseField name="iso2" type="string">
+  ISO 3166-1 alpha-2 code (e.g. `"US"`).
+</ResponseField>
+
+<ResponseField name="iso3" type="string">
+  ISO 3166-1 alpha-3 code (e.g. `"USA"`).
+</ResponseField>
+
+<RequestExample>
+```bash cURL (all countries)
+curl -X GET 'https://api.countrystatecity.in/v1/phone' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```bash cURL (reverse lookup)
+curl -X GET 'https://api.countrystatecity.in/v1/phone?code=%2B1' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```bash cURL (without URL-encoded +)
+curl -X GET 'https://api.countrystatecity.in/v1/phone?code=91' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```javascript JavaScript
+const response = await fetch(
+  'https://api.countrystatecity.in/v1/phone?code=' + encodeURIComponent('+44'),
+  { headers: { 'X-CSCAPI-KEY': 'YOUR_API_KEY' } }
+);
+
+const entries = await response.json();
+// entries: [{ country: "GB", dial_code: "+44", iso2: "GB", iso3: "GBR" }, ...]
+```
+
+```python Python
+import requests
+
+response = requests.get(
+  'https://api.countrystatecity.in/v1/phone',
+  params={'code': '+1'},
+  headers={'X-CSCAPI-KEY': 'YOUR_API_KEY'}
+)
+
+nanp_countries = response.json()
+print(f"{len(nanp_countries)} countries share +1")
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200 - Reverse lookup (?code=+1)
+[
+  { "country": "AG", "dial_code": "+1", "area_code": "268", "iso2": "AG", "iso3": "ATG" },
+  { "country": "AI", "dial_code": "+1", "area_code": "264", "iso2": "AI", "iso3": "AIA" },
+  { "country": "BB", "dial_code": "+1", "area_code": "246", "iso2": "BB", "iso3": "BRB" },
+  { "country": "BS", "dial_code": "+1", "area_code": "242", "iso2": "BS", "iso3": "BHS" },
+  { "country": "CA", "dial_code": "+1",                    "iso2": "CA", "iso3": "CAN" },
+  { "country": "US", "dial_code": "+1",                    "iso2": "US", "iso3": "USA" }
+]
+```
+
+```json 200 - Single country (?code=+91)
+[
+  { "country": "IN", "dial_code": "+91", "iso2": "IN", "iso3": "IND" }
+]
+```
+
+```json 400 - Empty code
+{
+  "error": "Invalid dial code. Provide a non-empty value (e.g., +1, 44)."
+}
+```
+
+```json 400 - Non-numeric / wrong length
+{
+  "error": "Invalid dial code format. Expected digits (e.g., 91, 1, 44)."
+}
+```
+
+```json 403 - Feature Restricted
+{
+  "error": "This feature is not available on your current plan.",
+  "feature": "phoneDialCode",
+  "upgradeUrl": "https://app.countrystatecity.in/pricing"
+}
+```
+</ResponseExample>
+
+## Related Endpoints
+
+- [Get Dial Code by Country](/api/endpoints/get-dial-code-by-country) — one country at a time when you already know the country
+- [Parse Phone Number](/api/endpoints/parse-phone-number) — given an E.164 number, identify the country

--- a/api/endpoints/lookup-country-by-iso.mdx
+++ b/api/endpoints/lookup-country-by-iso.mdx
@@ -1,0 +1,142 @@
+---
+title: "Lookup Country by ISO Code"
+api: "GET https://api.countrystatecity.in/v1/iso/country"
+authMethod: "key"
+description: "Find a country by ISO 3166-1 alpha-2, alpha-3, or numeric code"
+---
+
+Look up a single country by **any one** of the three ISO 3166-1 codes: 2-letter (alpha-2), 3-letter (alpha-3), or 3-digit numeric. Exactly one query parameter must be provided.
+
+This is the canonical lookup when you have an ISO code from an external system (payment gateway, geolocation service, address parser) and need to resolve it to the country record.
+
+<Note>**Availability:** Starter plan and above. Returns `403` on Community plan.</Note>
+
+<Info>Responses are cached server-side for 1 hour. The cache slot is shared with [`/v1/iso/country/convert`](/api/endpoints/convert-iso-code) — warming the cache via one endpoint serves the other for free. Numeric codes `4` and `004` resolve to the same cache slot.</Info>
+
+## Authentication
+
+<ParamField header="X-CSCAPI-KEY" type="string" required>
+  Your API key for authentication
+</ParamField>
+
+## Query Parameters
+
+Provide **exactly one** of the three. Sending two or zero returns `400`.
+
+<ParamField query="iso2" type="string">
+  ISO 3166-1 alpha-2 code, e.g. `US`, `IN`, `DE`. Case-insensitive (auto-uppercased).
+</ParamField>
+
+<ParamField query="iso3" type="string">
+  ISO 3166-1 alpha-3 code, e.g. `USA`, `IND`, `DEU`. Case-insensitive.
+</ParamField>
+
+<ParamField query="numeric" type="string">
+  ISO 3166-1 numeric code, 1–3 digits. Accepts padded (`004`) and unpadded (`4`) forms. All-zero values are rejected.
+</ParamField>
+
+## Response
+
+<ResponseField name="id" type="integer">
+  Internal CSC country ID — same value used by `/v1/countries/:id` and other foreign-key references.
+</ResponseField>
+
+<ResponseField name="name" type="string">
+  Official country name in English.
+</ResponseField>
+
+<ResponseField name="iso2" type="string">
+  ISO 3166-1 alpha-2 code (e.g. `"US"`).
+</ResponseField>
+
+<ResponseField name="iso3" type="string">
+  ISO 3166-1 alpha-3 code (e.g. `"USA"`).
+</ResponseField>
+
+<ResponseField name="numeric_code" type="string | null">
+  ISO 3166-1 numeric code, zero-padded to 3 digits (e.g. `"840"`). `null` for entries without an assigned numeric code.
+</ResponseField>
+
+<RequestExample>
+```bash cURL (alpha-2)
+curl -X GET 'https://api.countrystatecity.in/v1/iso/country?iso2=US' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```bash cURL (alpha-3)
+curl -X GET 'https://api.countrystatecity.in/v1/iso/country?iso3=IND' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```bash cURL (numeric)
+curl -X GET 'https://api.countrystatecity.in/v1/iso/country?numeric=840' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```javascript JavaScript
+const response = await fetch(
+  'https://api.countrystatecity.in/v1/iso/country?iso2=US',
+  { headers: { 'X-CSCAPI-KEY': 'YOUR_API_KEY' } }
+);
+
+const country = await response.json();
+console.log(`${country.name} (id ${country.id})`);
+```
+
+```python Python
+import requests
+
+response = requests.get(
+  'https://api.countrystatecity.in/v1/iso/country',
+  params={'iso3': 'USA'},
+  headers={'X-CSCAPI-KEY': 'YOUR_API_KEY'}
+)
+
+country = response.json()
+print(f"{country['name']} → numeric {country['numeric_code']}")
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200 - Success
+{
+  "id": 233,
+  "name": "United States",
+  "iso2": "US",
+  "iso3": "USA",
+  "numeric_code": "840"
+}
+```
+
+```json 400 - Wrong number of params
+{
+  "error": "Invalid query parameters: Provide exactly one of: iso2, iso3, numeric"
+}
+```
+
+```json 400 - Malformed code
+{
+  "error": "Invalid query parameters: iso2: must be a 2-letter code"
+}
+```
+
+```json 403 - Feature Restricted
+{
+  "error": "This feature is not available on your current plan.",
+  "feature": "isoLookup",
+  "upgradeUrl": "https://app.countrystatecity.in/pricing"
+}
+```
+
+```json 404 - No Match
+{
+  "error": "Country not found for the given code"
+}
+```
+</ResponseExample>
+
+## Related Endpoints
+
+- [Lookup State by ISO Code](/api/endpoints/lookup-state-by-iso) — same idea for ISO 3166-2 subdivision codes
+- [Convert ISO Code](/api/endpoints/convert-iso-code) — translate between alpha-2, alpha-3, and numeric in one call
+- [Get Country Details](/api/endpoints/get-country-details) — full country record (all fields, tier-gated)

--- a/api/endpoints/lookup-state-by-iso.mdx
+++ b/api/endpoints/lookup-state-by-iso.mdx
@@ -1,0 +1,145 @@
+---
+title: "Lookup State by ISO Code"
+api: "GET https://api.countrystatecity.in/v1/iso/state"
+authMethod: "key"
+description: "Find a state or province by ISO 3166-2 subdivision code"
+---
+
+Resolve an ISO 3166-2 subdivision code (e.g. `US-CA`, `IN-MH`, `DE-BY`) to the state/province record.
+
+The match prefers the canonical `iso3166_2` column. When that column is `NULL` for a row (common in older imports), the endpoint falls back to matching the legacy `iso2` column scoped to the same country — so the lookup works even for partially-coded rows without risking cross-country false matches.
+
+<Note>**Availability:** Starter plan and above. Returns `403` on Community plan.</Note>
+
+<Info>Responses are cached server-side for 1 hour. The lookup key is the full ISO 3166-2 code, so `US-CA` and `us-ca` collapse to the same cache slot (input is auto-uppercased).</Info>
+
+## Authentication
+
+<ParamField header="X-CSCAPI-KEY" type="string" required>
+  Your API key for authentication
+</ParamField>
+
+## Query Parameters
+
+<ParamField query="iso" type="string" required>
+  ISO 3166-2 subdivision code in the form `XX-YYY` — 2-letter country code, hyphen, then 1–3 alphanumeric characters for the subdivision. Case-insensitive (auto-uppercased).
+
+  Examples: `US-CA`, `IN-MH`, `DE-BY`, `GB-ENG`, `JP-13`
+</ParamField>
+
+## Response
+
+<ResponseField name="id" type="integer">
+  Internal CSC state ID — same value used by `/v1/states/:id` and as a foreign key from `/cities`.
+</ResponseField>
+
+<ResponseField name="name" type="string">
+  Official state/province name in English (e.g. `"California"`).
+</ResponseField>
+
+<ResponseField name="iso2" type="string | null">
+  Legacy subdivision code without the country prefix (e.g. `"CA"`). May be `null` for some entries.
+</ResponseField>
+
+<ResponseField name="iso3166_2" type="string | null">
+  Canonical ISO 3166-2 code (e.g. `"US-CA"`). May be `null` for older entries — the endpoint still resolves them via the `iso2` fallback.
+</ResponseField>
+
+<ResponseField name="country_id" type="integer">
+  Internal CSC country ID — foreign key into `/countries`.
+</ResponseField>
+
+<ResponseField name="country_code" type="string">
+  ISO 3166-1 alpha-2 code of the parent country (e.g. `"US"`).
+</ResponseField>
+
+<RequestExample>
+```bash cURL
+curl -X GET 'https://api.countrystatecity.in/v1/iso/state?iso=US-CA' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```bash cURL (case-insensitive)
+curl -X GET 'https://api.countrystatecity.in/v1/iso/state?iso=in-mh' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```javascript JavaScript
+const response = await fetch(
+  'https://api.countrystatecity.in/v1/iso/state?iso=US-CA',
+  { headers: { 'X-CSCAPI-KEY': 'YOUR_API_KEY' } }
+);
+
+const state = await response.json();
+console.log(`${state.name}, ${state.country_code} (id ${state.id})`);
+```
+
+```python Python
+import requests
+
+response = requests.get(
+  'https://api.countrystatecity.in/v1/iso/state',
+  params={'iso': 'DE-BY'},
+  headers={'X-CSCAPI-KEY': 'YOUR_API_KEY'}
+)
+
+state = response.json()
+print(state['name'])  # "Bavaria"
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200 - Success
+{
+  "id": 1416,
+  "name": "California",
+  "iso2": "CA",
+  "iso3166_2": "US-CA",
+  "country_id": 233,
+  "country_code": "US"
+}
+```
+
+```json 200 - Resolved via legacy fallback
+{
+  "id": 4022,
+  "name": "Maharashtra",
+  "iso2": "MH",
+  "iso3166_2": null,
+  "country_id": 101,
+  "country_code": "IN"
+}
+```
+
+```json 400 - Missing param
+{
+  "error": "Invalid query parameters: iso: is required (e.g. iso=US-CA)"
+}
+```
+
+```json 400 - Malformed code
+{
+  "error": "Invalid query parameters: iso: must be an ISO 3166-2 code (e.g. US-CA)"
+}
+```
+
+```json 403 - Feature Restricted
+{
+  "error": "This feature is not available on your current plan.",
+  "feature": "isoLookup",
+  "upgradeUrl": "https://app.countrystatecity.in/pricing"
+}
+```
+
+```json 404 - No Match
+{
+  "error": "State not found for the given ISO code"
+}
+```
+</ResponseExample>
+
+## Related Endpoints
+
+- [Lookup Country by ISO Code](/api/endpoints/lookup-country-by-iso) — country-level ISO lookup (alpha-2/alpha-3/numeric)
+- [Get State Details](/api/endpoints/get-state-details) — full state record (all fields, tier-gated)
+- [Get States by Country](/api/endpoints/get-states-by-country) — all states for a given country

--- a/api/endpoints/parse-phone-number.mdx
+++ b/api/endpoints/parse-phone-number.mdx
@@ -1,0 +1,187 @@
+---
+title: "Parse Phone Number"
+api: "GET https://api.countrystatecity.in/v1/phone/parse"
+authMethod: "key"
+description: "Parse an E.164 phone number into its country and national parts"
+---
+
+Given a phone number in E.164 format (`+` followed by country code and national digits), identify the originating country and split out the national portion.
+
+The matcher walks 3-digit → 2-digit → 1-digit ITU prefixes, so longer-prefix countries (like `+972` Israel) win over shorter-prefix ones that share the leading digit. For NANP `+1` numbers, the area code is matched against known territory area codes — `+1-246-555-1234` resolves to Barbados (`BB`), not the US.
+
+<Note>**Availability:** Supporter plan and above. Returns `403` on lower tiers.</Note>
+
+<Warning>
+**The response echoes the phone number** (`e164` and `national_number`), so it's PII. The endpoint returns `Cache-Control: no-store` and emits no `ETag` — Cloudflare, browsers, and intermediate proxies will not retain the response. Do not change this if you're proxying through additional caching layers; the `Cache-Control` is intentional.
+
+The **internal phone-prefix index** is cached server-side for 24 hours. The `X-Parse-Index-Cache: HIT|MISS` header reports whether that internal lookup was a cache hit — it does **not** describe the response body.
+</Warning>
+
+## Authentication
+
+<ParamField header="X-CSCAPI-KEY" type="string" required>
+  Your API key for authentication
+</ParamField>
+
+## Query Parameters
+
+<ParamField query="number" type="string" required>
+  E.164-formatted phone number starting with `+` followed by 5–15 digits.
+
+  Both `+14155552671` and the URL-decoded form ` 14155552671` (with a leading space, which is how some HTTP clients deliver an unencoded `+`) are accepted.
+</ParamField>
+
+## Response
+
+<ResponseField name="country" type="string">
+  ISO 3166-1 alpha-2 code of the matched country (e.g. `"BB"`). Convenience field equal to `iso2`.
+</ResponseField>
+
+<ResponseField name="dial_code" type="string">
+  Country dial code with leading `+` (e.g. `"+1"`).
+</ResponseField>
+
+<ResponseField name="area_code" type="string">
+  Present only for NANP matches with a fixed area-code prefix (e.g. `"246"` for Barbados). Omitted when not applicable.
+</ResponseField>
+
+<ResponseField name="iso2" type="string">
+  ISO 3166-1 alpha-2 code.
+</ResponseField>
+
+<ResponseField name="iso3" type="string">
+  ISO 3166-1 alpha-3 code.
+</ResponseField>
+
+<ResponseField name="national_number" type="string">
+  Digits remaining after stripping the country dial code (no `+`, no separators). For NANP numbers this **includes** the area code — the area code is part of the national format.
+</ResponseField>
+
+<ResponseField name="e164" type="string">
+  Echo of the normalized input (always starts with `+`).
+</ResponseField>
+
+<RequestExample>
+```bash cURL (US number)
+curl -X GET 'https://api.countrystatecity.in/v1/phone/parse?number=%2B14155552671' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```bash cURL (Indian number)
+curl -X GET 'https://api.countrystatecity.in/v1/phone/parse?number=%2B919876543210' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```bash cURL (NANP territory — Barbados)
+curl -X GET 'https://api.countrystatecity.in/v1/phone/parse?number=%2B12465551234' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```javascript JavaScript
+const number = '+14155552671';
+const response = await fetch(
+  `https://api.countrystatecity.in/v1/phone/parse?number=${encodeURIComponent(number)}`,
+  { headers: { 'X-CSCAPI-KEY': 'YOUR_API_KEY' } }
+);
+
+const parsed = await response.json();
+// { country: "US", dial_code: "+1", iso2: "US", iso3: "USA",
+//   national_number: "4155552671", e164: "+14155552671" }
+```
+
+```python Python
+import requests
+
+response = requests.get(
+  'https://api.countrystatecity.in/v1/phone/parse',
+  params={'number': '+919876543210'},
+  headers={'X-CSCAPI-KEY': 'YOUR_API_KEY'}
+)
+
+parsed = response.json()
+print(f"{parsed['country']} | {parsed['dial_code']} | national {parsed['national_number']}")
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200 - US number
+{
+  "country": "US",
+  "dial_code": "+1",
+  "iso2": "US",
+  "iso3": "USA",
+  "national_number": "4155552671",
+  "e164": "+14155552671"
+}
+```
+
+```json 200 - NANP territory (area-code disambiguation)
+{
+  "country": "BB",
+  "dial_code": "+1",
+  "area_code": "246",
+  "iso2": "BB",
+  "iso3": "BRB",
+  "national_number": "2465551234",
+  "e164": "+12465551234"
+}
+```
+
+```json 200 - 3-digit ITU prefix wins
+{
+  "country": "IL",
+  "dial_code": "+972",
+  "iso2": "IL",
+  "iso3": "ISR",
+  "national_number": "501234567",
+  "e164": "+972501234567"
+}
+```
+
+```json 400 - Missing param
+{
+  "error": "Missing required query parameter: number"
+}
+```
+
+```json 400 - No leading +
+{
+  "error": "Phone number must be in E.164 format starting with + (e.g., +14155552671)."
+}
+```
+
+```json 400 - Wrong digit count
+{
+  "error": "Invalid phone number. Must contain 5-15 digits after the +."
+}
+```
+
+```json 403 - Feature Restricted
+{
+  "error": "This feature is not available on your current plan.",
+  "feature": "phoneDialCode",
+  "upgradeUrl": "https://app.countrystatecity.in/pricing"
+}
+```
+
+```json 404 - No matching country
+{
+  "error": "Could not identify a country for the given phone number."
+}
+```
+</ResponseExample>
+
+## Notes on Matching
+
+The matcher tries 3-digit, then 2-digit, then 1-digit ITU prefixes:
+
+- `+972...` matches Israel (3-digit prefix), not Yemen (`+967`) or any 1-digit `+9` country (none exist, but the logic generalizes).
+- `+44...` matches the UK (2-digit prefix).
+- `+1...` is the NANP — the next 3 digits are checked against known area codes (Barbados `246`, Antigua `268`, etc.). If no area code matches, the request falls back to the US.
+
+When the data carries a `+1-XXX` area-code prefix for a country, the matcher prefers that more-specific entry over the bare `+1`.
+
+## Related Endpoints
+
+- [Get Dial Code by Country](/api/endpoints/get-dial-code-by-country) — when you already know the country
+- [List Dial Codes](/api/endpoints/list-dial-codes) — every country plus reverse lookup

--- a/api/field-filtering-and-sorting.mdx
+++ b/api/field-filtering-and-sorting.mdx
@@ -1,0 +1,207 @@
+---
+title: "Field Filtering & Sorting"
+description: "Reduce payload size and order results with ?fields= and ?sort= on every geographic endpoint"
+---
+
+Every geographic endpoint accepts two query parameters that let you shape the response payload without changing the URL:
+
+- **`?fields=`** — return only the fields you ask for. Trim large list responses down to what your UI actually renders.
+- **`?sort=`** — order list results by one or more fields, ascending or descending.
+
+<Note>**Availability:** Both parameters require the **Supporter plan or above**. Detail endpoints accept `?fields=`; list endpoints accept both `?fields=` and `?sort=`.</Note>
+
+<Info>Filtering and sorting are applied **server-side after cache**, so a typical request still takes <10 ms even on large responses. The full payload is cached once; each `?fields=`/`?sort=` permutation receives its own ETag.</Info>
+
+---
+
+## `?fields=` — request only the columns you need
+
+Pass a comma-separated list of field names. The response includes only those fields, plus `id` (always returned so responses are never empty).
+
+```bash
+# Return only name + iso2 for every country
+curl -X GET 'https://api.countrystatecity.in/v1/countries?fields=name,iso2' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```json 200 - Trimmed response
+[
+  { "id": 1, "name": "Afghanistan", "iso2": "AF" },
+  { "id": 2, "name": "Albania",     "iso2": "AL" },
+  { "id": 3, "name": "Algeria",     "iso2": "DZ" }
+]
+```
+
+### Behaviour rules
+
+| Input | Behaviour |
+|---|---|
+| Field name is **unknown** for that entity | `400 Bad Request` listing valid fields |
+| Field is **valid but outside your tier** | Silently dropped — response stays a 200, that field just doesn't appear |
+| Field list is **empty** (`?fields=`) | Treated as if the parameter wasn't sent (no filtering). Still trips the Supporter+ check. |
+| `id` not in your list | Added automatically — every response item carries `id` |
+| `?fields=` sent multiple times | `400 Bad Request` — repeated params arrive as an array, which is rejected. Send one comma-separated list. |
+
+### Per-entity field lists
+
+The fields available to `?fields=` are the same as the columns returned by each endpoint (after tier gating). For the full lists, see the **Tier-Based Field Availability** table at the bottom of every endpoint page.
+
+---
+
+## `?sort=` — order list results
+
+Pass a comma-separated list of `field` or `field:asc|desc` tokens. Sort is applied to the list **after filtering**.
+
+```bash
+# Largest countries by population, descending
+curl -X GET 'https://api.countrystatecity.in/v1/countries?fields=name,population&sort=population:desc' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+```json 200 - Top of response
+[
+  { "id": 45,  "name": "China",         "population": 1444216107 },
+  { "id": 101, "name": "India",         "population": 1380004385 },
+  { "id": 233, "name": "United States", "population":  331002651 }
+]
+```
+
+### Multi-field sort
+
+Chain fields with commas — earlier tokens take precedence on ties.
+
+```bash
+# Region first (A→Z), population second (largest first within each region)
+curl -X GET 'https://api.countrystatecity.in/v1/countries?sort=region:asc,population:desc' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+### Sortable fields per entity
+
+Only fields with comparable scalar values are sortable. Translation blobs, JSON columns, and similar non-scalar columns are not.
+
+| Entity | Sortable fields |
+|---|---|
+| countries | `id`, `name`, `iso2`, `iso3`, `population`, `gdp`, `area_sq_km`, `latitude`, `longitude` |
+| states | `id`, `name`, `iso2`, `country_code`, `population`, `latitude`, `longitude` |
+| cities | `id`, `name`, `state_code`, `country_code`, `population`, `latitude`, `longitude` |
+| regions | `id`, `name` |
+| subregions | `id`, `name`, `region_id` |
+
+### Behaviour rules
+
+| Input | Behaviour |
+|---|---|
+| Field is not in the sortable list above | `400 Bad Request` listing the valid fields |
+| Field is sortable but **outside your tier** (e.g. `population` on Starter) | `400 Bad Request` — sort surfaces a clear error instead of silently dropping, so you don't get nonsense order |
+| Direction is anything other than `asc` or `desc` (case-insensitive) | `400 Bad Request` |
+| Token has more than one `:` (e.g. `name:asc:extra`) | `400 Bad Request` — guards against silently swallowed typos |
+| Empty `?sort=` | Treated as if the parameter wasn't sent. Still trips the Supporter+ check. |
+| `?sort=` sent on a detail endpoint (e.g. `/countries/IN`) | Ignored — sort only applies to list endpoints |
+| Numeric strings (`latitude`, `longitude`) | Compared numerically, not lexicographically. `"9.0"` sorts before `"10.0"`. |
+| `null` values | Sorted first in `asc`, last in `desc` |
+
+### Whitespace
+
+Whitespace inside a sort token is tolerated. Both `sort=name:desc` and `sort=name: desc` are valid.
+
+---
+
+## Combining `?fields=` and `?sort=`
+
+You can use both together. Sort is applied first, then fields are trimmed.
+
+```bash
+curl -X GET 'https://api.countrystatecity.in/v1/cities?fields=name,population&sort=population:desc' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+You can sort by a field you didn't include in `?fields=` — the sort happens on the full row, then unwanted columns are dropped.
+
+```bash
+# Sort by population (not returned), keep only the city name
+curl -X GET 'https://api.countrystatecity.in/v1/cities?fields=name&sort=population:desc' \
+  -H 'X-CSCAPI-KEY: YOUR_API_KEY'
+```
+
+---
+
+## Caching
+
+| Header | Meaning |
+|---|---|
+| `Cache-Control: public, max-age=86400` | The underlying full payload is cached server-side and at the edge for 24 h |
+| `ETag` | Each `?fields=`/`?sort=` permutation gets its own ETag so conditional requests work per-permutation |
+| `X-Cache: HIT` / `MISS` | Whether the **underlying** entity payload was served from cache. Filtering and sorting always run on the response — they're cheap relative to network round-trip. |
+
+---
+
+## Error responses
+
+```json 400 - Unknown field in ?fields=
+{
+  "error": "Unknown field(s): fakeColumn. Valid fields: id, name, iso2, iso3, ..."
+}
+```
+
+```json 400 - Non-sortable field
+{
+  "error": "Field \"timezones\" is not sortable. Sortable fields for countries: id, name, iso2, iso3, population, gdp, area_sq_km, latitude, longitude"
+}
+```
+
+```json 400 - Sort field outside tier
+{
+  "error": "Field \"population\" is not available on your current plan."
+}
+```
+
+```json 400 - Malformed sort token
+{
+  "error": "Invalid sort token \"name:asc:extra\". Expected \"field\" or \"field:asc|desc\"."
+}
+```
+
+```json 403 - Feature not on plan
+{
+  "error": "This feature is not available on your current plan.",
+  "feature": "fieldsFiltering",
+  "upgradeUrl": "https://app.countrystatecity.in/pricing"
+}
+```
+
+---
+
+## When to use which parameter
+
+<AccordionGroup>
+<Accordion title="Cutting payload for a dropdown / typeahead">
+  Use `?fields=` to keep only the columns the UI renders. A country selector usually needs `id`, `name`, `iso2`, `emoji` — that's roughly 1 KB per request instead of 50+ KB for the full response.
+
+  ```bash
+  curl 'https://api.countrystatecity.in/v1/countries?fields=name,iso2,emoji'
+  ```
+</Accordion>
+
+<Accordion title="Ordering a list for display">
+  Use `?sort=` to push the work server-side. Sorting 150,000 cities by population in your client is slow and ships a lot of data you'll discard.
+
+  ```bash
+  curl 'https://api.countrystatecity.in/v1/cities?sort=population:desc&fields=name,state_code,population'
+  ```
+</Accordion>
+
+<Accordion title="Both at once for a paginated table">
+  Combine `?fields=` and `?sort=` to ship exactly the rendered columns in the rendered order. Pair with client-side slicing for pagination.
+
+  ```bash
+  curl 'https://api.countrystatecity.in/v1/states?sort=name:asc&fields=name,iso2,country_code'
+  ```
+</Accordion>
+</AccordionGroup>
+
+## Related Topics
+
+- [Authentication](/api/authentication) — how to send `X-CSCAPI-KEY`
+- [Pricing](https://app.countrystatecity.in/pricing) — which plans include filtering and sorting
+- Every endpoint page links back to this guide

--- a/docs.json
+++ b/docs.json
@@ -30,6 +30,7 @@
             "pages": [
               "api/introduction",
               "api/authentication",
+              "api/field-filtering-and-sorting",
               "api/faq"
             ]
           },
@@ -70,6 +71,30 @@
             "pages": [
               "api/endpoints/list-all-currencies",
               "api/endpoints/get-currency-by-country"
+            ]
+          },
+          {
+            "group": "ISO Code Endpoints",
+            "pages": [
+              "api/endpoints/lookup-country-by-iso",
+              "api/endpoints/lookup-state-by-iso",
+              "api/endpoints/convert-iso-code"
+            ]
+          },
+          {
+            "group": "Phone Endpoints",
+            "pages": [
+              "api/endpoints/list-dial-codes",
+              "api/endpoints/get-dial-code-by-country",
+              "api/endpoints/parse-phone-number"
+            ]
+          },
+          {
+            "group": "Timezone Endpoints",
+            "pages": [
+              "api/endpoints/get-timezone-by-country",
+              "api/endpoints/get-timezone-by-state",
+              "api/endpoints/get-timezone-by-city"
             ]
           },
           {

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,11 @@ This comprehensive Mintlify documentation site covers the complete Country State
 - Real-time data access with authentication via X-CSCAPI-KEY headers
 - High-performance JSON responses with sub-100ms response times globally
 - Base URL: https://api.countrystatecity.in/v1
-- Complete endpoint coverage for countries, states, and cities
+- Complete endpoint coverage for countries, states, cities, regions, currencies
+- ISO 3166-1 / 3166-2 lookup endpoints (alpha-2, alpha-3, numeric codes + state subdivisions)
+- Phone dial-code endpoints including reverse lookup and E.164 number parsing
+- Timezone endpoints by country, state, and city with DST awareness
+- Field filtering (?fields=) and custom sort (?sort=) on every geographic endpoint (Supporter+)
 
 ### CSC Database
 - Complete geographical database with regular updates


### PR DESCRIPTION
## Summary

Brings docs back in sync with csc-app production. Four user-facing features shipped over the last week without docs coverage — fixing that here.

| Feature | csc-app PR | Pages added | Tier |
|---|---|---|---|
| ISO 3166 lookup endpoints | #29 | 3 endpoint pages | Starter+ |
| Phone dial code + E.164 parser | #26 | 3 endpoint pages | Supporter+ |
| Timezone lookup by country/state/city | #24 | 3 endpoint pages | All plans (key only) |
| Field filtering + custom sort | #33 | 1 cross-cutting guide + callouts on every geographic endpoint | Supporter+ |

## Cross-cutting guide

`api/field-filtering-and-sorting.mdx` — one canonical page covering:

- `?fields=` syntax + behaviour rules (unknown field → 400, tier-gated field → silently dropped, repeated param → 400, `id` always present)
- `?sort=` syntax + per-entity sortable-fields table (countries / states / cities / regions / subregions)
- Combined `?fields=` + `?sort=` usage
- Caching semantics (`X-Cache`, per-permutation `ETag`, 24h server-side TTL)
- Real error-response JSON copied verbatim from `planGuard.ts` so devs can paste it into their own retry handlers

## Per-endpoint callouts

Every geographic list endpoint (8) and detail endpoint (4) now has a short `<Tip>` block right above `## Authentication` linking back to the guide. List variant mentions both `?fields=` and `?sort=`; detail variant mentions only `?fields=` (sort doesn't apply to detail routes). Currency endpoints are intentionally excluded — they don't use the `Entity` enum that powers `getFieldsAndSort`.

## Navigation

`docs.json` gains 3 new groups in display order:

```
Currency Endpoints       (existing)
ISO Code Endpoints       ← new
Phone Endpoints          ← new
Timezone Endpoints       ← new
SDKs & Examples          (existing)
```

The fields/sort guide goes into the existing "API Documentation" group between `authentication` and `faq` (it's a conceptual reference, not an endpoint).

## llms.txt

Surfaced the new endpoint groups + the `?fields=`/`?sort=` capability so AI assistants pick them up.

## Followups out of scope

- **Tier-matrix re-sync:** `scripts/sync-tier-matrices.js` lives on the unmerged `feat/sync-tier-matrices` branch. Once that merges to main, run `npm run sync-tier-matrices` to regenerate the `<!-- AUTOGEN:tier-matrix -->` blocks. No drift on existing pages since `pricingTiers.ts` access levels didn't change for those tables.
- **`changelog.mdx`:** Auto-synced from GitHub releases — it'll pick up the next docs release tag.

## Test plan
- [x] `python3 -c "import json; json.load(open('docs.json'))"` — JSON valid
- [ ] `mintlify dev` locally to verify nav renders + all internal links resolve
- [ ] Smoke-check a couple of code samples (cURL paths against production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)