### PR TITLE
fix(docs): unbreak field-filtering page (MDX parse error on bare <10)

### DIFF
--- a/api/field-filtering-and-sorting.mdx
+++ b/api/field-filtering-and-sorting.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Field Filtering & Sorting"
+title: "Field Filtering and Sorting"
 description: "Reduce payload size and order results with ?fields= and ?sort= on every geographic endpoint"
+icon: "filter"
 ---
 
 Every geographic endpoint accepts two query parameters that let you shape the response payload without changing the URL:
@@ -10,7 +11,7 @@ Every geographic endpoint accepts two query parameters that let you shape the re
 
 <Note>**Availability:** Both parameters require the **Supporter plan or above**. Detail endpoints accept `?fields=`; list endpoints accept both `?fields=` and `?sort=`.</Note>
 
-<Info>Filtering and sorting are applied **server-side after cache**, so a typical request still takes <10 ms even on large responses. The full payload is cached once; each `?fields=`/`?sort=` permutation receives its own ETag.</Info>
+<Info>Filtering and sorting are applied **server-side after cache**, so a typical request still takes under 10 ms even on large responses. The full payload is cached once; each `?fields=`/`?sort=` permutation receives its own ETag.</Info>
 
 ---
 


### PR DESCRIPTION
## Symptom

The "Field filtering and sorting" entry appears in the API Documentation sidebar but the page 404s. The sidebar entry also renders with no icon and a slug-derived title ("Field filtering and sorting") instead of the configured frontmatter title — both are Mintlify's signals that the file couldn't be parsed.

## Root cause

Line 13 of `api/field-filtering-and-sorting.mdx`:

> "Filtering and sorting are applied **server-side after cache**, so a typical request still takes \`<10 ms\` even on large responses."

In MDX, `<` followed by a non-letter character is the start of a JSX element. `<10` is interpreted as a tag with name `10`, which isn't a valid React component name, so the parser bails and the page fails to compile. Mintlify silently falls back to a synthesized sidebar entry and serves 404 for the route — no error surfaced in the rendered site.

The original PR #5 wasn't built locally with \`mintlify dev\` before merging, which would have caught the parse error in the terminal. Filed mentally for future docs PRs.

## Fix

| Change | Why |
|---|---|
| `<10 ms` → `under 10 ms` | The actual unblock. Identical meaning, MDX-safe wording. |
| Added `icon: "filter"` to frontmatter | Other API Documentation siblings (introduction/globe, authentication/key, faq/circle-question) all have icons. Without one, even after the parse fix, the sidebar entry looks visually orphaned. |
| Title `"Field Filtering & Sorting"` → `"Field Filtering and Sorting"` | Independent precaution. `&` in titles renders fine in the page but can need HTML-entity encoding in other surfaces (RSS, OpenGraph, llms.txt consumers). "and" removes the variable. |

## Verification

After merge, open https://docs.countrystatecity.in/api/field-filtering-and-sorting — should render with the filter icon in the sidebar and the title "Field Filtering and Sorting".

## Test plan

- [x] grep all new endpoint pages added in #5 for the same `<digit` / `<lowercase-no-letter-after` pattern — only this one occurrence found
- [ ] `mintlify dev` locally to confirm the page renders cleanly
- [ ] Spot-check the sidebar after the production rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)