### PR TITLE
docs: fix stale and contradictory dataset counts

### DIFF
--- a/.cursor/rules/project-specs.mdc
+++ b/.cursor/rules/project-specs.mdc
@@ -199,7 +199,7 @@ countries = csc.get_countries()
 #### Cards for highlighting features
 ```mdx
 <Card title="Countries API" icon="globe" href="/api/countries">
-Access data for 247+ countries with ISO codes, phone codes, and currencies.
+Access data for 250+ countries with ISO codes, phone codes, and currencies.
 </Card>
 
 <CardGroup cols={2}>
@@ -207,7 +207,7 @@ Access data for 247+ countries with ISO codes, phone codes, and currencies.
   Get states, provinces, and regions for any country.
 </Card>
 <Card title="Cities API" icon="building" href="/api/cities">
-  Access 150,000+ cities with coordinates and timezone data.
+  Access 153,000+ cities with coordinates and timezone data.
 </Card>
 </CardGroup>
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Project Overview
 
 This is a Mintlify-based documentation site for the Country State City (CSC) ecosystem. The ecosystem includes:
-- **CSC API**: REST API for 247+ countries, 5,000+ states, 150,000+ cities
+- **CSC API**: REST API for 250+ countries, 5,000+ states, 153,000+ cities
 - **Database**: Self-hosted geographical data in multiple formats
 - **Update Tool**: Community data submission and corrections
 - **Export Tool**: Data export in JSON, CSV, SQL, XML formats

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 The Country State City ecosystem is a complete geographical data solution that provides developers with:
 
-- **REST API**: Access to 247+ countries, 5,000+ states/provinces, and 150,000+ cities
+- **REST API**: Access to 250+ countries, 5,000+ states/provinces, and 153,000+ cities
 - **Database**: Ready-to-use geographical data in multiple database formats
 - **Tools**: Export and update tools for data management
 - **SDKs**: Official libraries for popular programming languages

--- a/api/faq.mdx
+++ b/api/faq.mdx
@@ -221,7 +221,7 @@ icon: "circle-question"
   We implement automated validation and quality checks to ensure data accuracy. Major updates are announced through our changelog.
 
   <Info>
-  The dataset includes 247+ countries, 5,000+ states/provinces, and 151,000+ cities worldwide.
+  The dataset includes 250+ countries, 5,000+ states/provinces, and 153,000+ cities worldwide.
   </Info>
 </Accordion>
 
@@ -240,7 +240,7 @@ icon: "circle-question"
   - More manageable response sizes
 
   <Warning>
-  Requesting all cities globally would result in 151,000+ records, which would be slow and consume significant bandwidth.
+  Requesting all cities globally would result in 153,000+ records, which would be slow and consume significant bandwidth.
   </Warning>
 </Accordion>
 
@@ -515,7 +515,7 @@ icon: "circle-question"
   ```
 
   <Check>
-  A successful countries request should return 247+ countries with proper ISO codes.
+  A successful countries request should return 250+ countries with proper ISO codes.
   </Check>
 </Accordion>
 </AccordionGroup>

--- a/api/field-filtering-and-sorting.mdx
+++ b/api/field-filtering-and-sorting.mdx
@@ -185,7 +185,7 @@ curl -X GET 'https://api.countrystatecity.in/v1/cities?fields=name&sort=populati
 </Accordion>
 
 <Accordion title="Ordering a list for display">
-  Use `?sort=` to push the work server-side. Sorting 150,000 cities by population in your client is slow and ships a lot of data you'll discard.
+  Use `?sort=` to push the work server-side. Sorting 153,000 cities by population in your client is slow and ships a lot of data you'll discard.
 
   ```bash
   curl 'https://api.countrystatecity.in/v1/cities?sort=population:desc&fields=name,state_code,population'

--- a/api/introduction.mdx
+++ b/api/introduction.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Country State City API"
-description: "Access comprehensive geographical data with our RESTful API featuring 247+ countries, 5000+ states, and 151,000+ cities"
+description: "Access comprehensive geographical data with our RESTful API featuring 250+ countries, 5000+ states, and 153,000+ cities"
 icon: "globe"
 ---
 
 ## Overview
 
-The Country State City API provides developers with comprehensive access to geographical data covering 247+ countries, 5000+ states/provinces, and over 151,000 cities worldwide. Our RESTful API is designed for high performance, reliability, and ease of integration.
+The Country State City API provides developers with comprehensive access to geographical data covering 250+ countries, 5000+ states/provinces, and over 153,000 cities worldwide. Our RESTful API is designed for high performance, reliability, and ease of integration.
 
 <Card
   title="Get your API key"

--- a/database/installation/duckdb.mdx
+++ b/database/installation/duckdb.mdx
@@ -83,8 +83,8 @@ DuckDB can directly query SQLite databases without conversion:
   Expected output:
   ```
   countries: 250
-  states: 5038
-  cities: 151024
+  states: 5299
+  cities: 153765
   ```
 </Step>
 </Steps>

--- a/database/installation/index.mdx
+++ b/database/installation/index.mdx
@@ -96,8 +96,8 @@ Before installing any database format:
 After installation, your database will contain:
 
 - **250 Countries** with ISO codes, regions, and metadata
-- **5,038 States/Provinces** with administrative codes
-- **151,024 Cities** with coordinates and timezone data
+- **5,299 States/Provinces** with administrative codes
+- **153,765 Cities** with coordinates and timezone data
 
 <Info>
 All data is regularly updated and includes comprehensive geographical information for worldwide coverage.

--- a/database/installation/mongodb.mdx
+++ b/database/installation/mongodb.mdx
@@ -65,8 +65,8 @@ MongoDB uses BSON (Binary JSON) format rather than SQL, so the installation proc
   {
     "regions": 5,
     "countries": 250,
-    "states": 5038,
-    "cities": 151024
+    "states": 5299,
+    "cities": 153765
   }
   ```
 </Step>

--- a/database/installation/mysql.mdx
+++ b/database/installation/mysql.mdx
@@ -57,10 +57,10 @@ Before starting, ensure you have:
   |    250    |
 
   | states |
-  |  5038  |
+  |  5299  |
 
   | cities |
-  | 151024 |
+  | 153765 |
   ```
 </Step>
 </Steps>

--- a/database/installation/postgresql.mdx
+++ b/database/installation/postgresql.mdx
@@ -63,8 +63,8 @@ Before starting, ensure you have:
    table_name | count  
   ------------|--------
    countries  |   250
-   states     |  5038
-   cities     | 151024
+   states     |  5299
+   cities     | 153765
   ```
 </Step>
 </Steps>

--- a/database/installation/sql-server.mdx
+++ b/database/installation/sql-server.mdx
@@ -80,8 +80,8 @@ SQL Server provides advanced enterprise features like partitioning, columnstore 
   ```
   table_name    record_count
   countries     250
-  states        5038
-  cities        151024
+  states        5299
+  cities        153765
   ```
 </Step>
 </Steps>

--- a/database/installation/sqlite.mdx
+++ b/database/installation/sqlite.mdx
@@ -63,8 +63,8 @@ SQLite databases are self-contained files that don't require a separate server i
   ```
   table_name|count
   countries|250
-  states|5038
-  cities|151024
+  states|5299
+  cities|153765
   ```
 </Step>
 </Steps>

--- a/database/overview.mdx
+++ b/database/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Database Overview"
-description: "Complete geographical database with 250+ countries, 5000+ states, and 151,000+ cities in multiple formats"
+description: "Complete geographical database with 250+ countries, 5,000+ states, and 153,000+ cities in multiple formats"
 icon: "database"
 ---
 
@@ -35,17 +35,17 @@ Our database contains comprehensive geographical data covering the entire world:
     <div className="text-sm text-purple-600">Countries</div>
   </div>
   <div className="text-center p-4 bg-orange-50 rounded-lg">
-    <div className="text-2xl font-bold text-orange-600">5,038</div>
+    <div className="text-2xl font-bold text-orange-600">5,299</div>
     <div className="text-sm text-orange-600">States</div>
   </div>
   <div className="text-center p-4 bg-red-50 rounded-lg">
-    <div className="text-2xl font-bold text-red-600">151,024</div>
+    <div className="text-2xl font-bold text-red-600">153,765</div>
     <div className="text-sm text-red-600">Cities</div>
   </div>
 </div>
 
 <Info>
-Last Updated: 21st September 2025
+Last Updated: 21st June 2026
 </Info>
 
 ## Available Formats

--- a/index.mdx
+++ b/index.mdx
@@ -4,7 +4,7 @@ description: "Complete geographical data ecosystem with API, database tools, and
 icon: "pen-to-square"
 ---
 
-The most comprehensive geographical data platform providing accurate, up-to-date information for **247+ countries**, **5,000+ states/provinces**, and **150,000+ cities** worldwide. Our ecosystem includes a powerful REST API, database tools, and export utilities designed for developers building location-aware applications.
+The most comprehensive geographical data platform providing accurate, up-to-date information for **250+ countries**, **5,000+ states/provinces**, and **153,000+ cities** worldwide. Our ecosystem includes a powerful REST API, database tools, and export utilities designed for developers building location-aware applications.
 
 <Note>
 All data includes ISO codes, coordinates, timezones, phone codes, currencies, and administrative hierarchies to support any geographical use case.
@@ -33,13 +33,13 @@ Production-ready API serving geographical data with sub-100ms response times glo
 
 <CardGroup cols={2}>
 <Card title="Countries API" icon="globe" href="/api/endpoints/get-all-countries">
-  Access data for 247+ countries with ISO codes, phone codes, and currencies
+  Access data for 250+ countries with ISO codes, phone codes, and currencies
 </Card>
 <Card title="States API" icon="map" href="/api/endpoints/get-states-by-country">
   Get states, provinces, and regions for any country
 </Card>
 <Card title="Cities API" icon="building" href="/api/endpoints/get-cities-by-state">
-  Access 150,000+ cities with coordinates and timezone data
+  Access 153,000+ cities with coordinates and timezone data
 </Card>
 <Card title="Authentication" icon="shield" href="/api/authentication">
   Secure API access with API keys

--- a/llms.txt
+++ b/llms.txt
@@ -5,7 +5,7 @@ This comprehensive Mintlify documentation site covers the complete Country State
 ## Core Products & Services
 
 ### Country State City API
-- REST API with 247+ countries, 5000+ states/provinces, 151,000+ cities
+- REST API with 250+ countries, 5000+ states/provinces, 153,000+ cities
 - Real-time data access with authentication via X-CSCAPI-KEY headers
 - High-performance JSON responses with sub-100ms response times globally
 - Base URL: https://api.countrystatecity.in/v1

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,14 +36,14 @@ npm run update-database-stats
    Regions: 6
    Subregions: 22
    Countries: 250
-   States: 5,038
-   Cities: 151,024
+   States: 5,299
+   Cities: 153,765
 
 📝 Updating overview.mdx file...
 ✅ Successfully updated overview.mdx with new statistics
 
 🎉 Successfully updated database statistics!
-📅 Updated date: 21st September 2025
+📅 Updated date: 21st June 2026
 ```
 
 ### sync-changelog.js

--- a/scripts/update-database-stats.js
+++ b/scripts/update-database-stats.js
@@ -53,8 +53,8 @@ function parseStatistics(readmeContent) {
   // Total Regions : 6 <br>
   // Total Sub Regions : 22 <br>
   // Total Countries : 250 <br>
-  // Total States/Regions/Municipalities : 5,038 <br>
-  // Total Cities/Towns/Districts : 151,024 <br>
+  // Total States/Regions/Municipalities : 5,299 <br>
+  // Total Cities/Towns/Districts : 153,765 <br>
 
   const patterns = [
     /Total\s+Regions?\s*:\s*(\d+(?:,\d+)*)/i,

--- a/tools/export-tool/faq.mdx
+++ b/tools/export-tool/faq.mdx
@@ -73,7 +73,7 @@ Credits are used to generate exports based on datasets and formats:
 **Dataset Costs:**
 - **Countries**: 1 credit (~250 countries)
 - **States**: 3 credits (~5,000 states/provinces)
-- **Cities**: 4 credits (~150,000 cities)
+- **Cities**: 4 credits (~153,000 cities)
 
 **Format Costs (added to dataset cost):**
 - **JSON / NDJSON / XML / YAML**: +2 credits
@@ -525,7 +525,7 @@ File sizes vary by dataset, fields selected, and format:
 <Tabs>
 <Tab title="JSON Format">
 **Countries Only:**
-- ~247 countries: 200-300 KB
+- ~250 countries: 200-300 KB
 - With all fields: 500 KB - 1 MB
 
 **Countries + States:**
@@ -533,13 +533,13 @@ File sizes vary by dataset, fields selected, and format:
 - Compressed: 500 KB - 1 MB
 
 **All Datasets:**
-- ~150,000 cities: 50-100 MB
+- ~153,000 cities: 50-100 MB
 - Compressed: 10-20 MB
 </Tab>
 
 <Tab title="CSV Format">
 **Countries Only:**
-- ~247 countries: 100-200 KB
+- ~250 countries: 100-200 KB
 - More compact than JSON
 
 **Countries + States:**

--- a/tools/export-tool/formats.mdx
+++ b/tools/export-tool/formats.mdx
@@ -688,7 +688,7 @@ Human-readable format perfect for configuration files, documentation, and DevOps
 metadata:
   export_date: "2024-01-15T10:30:00Z"
   version: "1.0"
-  total_countries: 247
+  total_countries: 250
   fields:
     - name
     - iso2

--- a/tools/export-tool/use-cases.mdx
+++ b/tools/export-tool/use-cases.mdx
@@ -206,7 +206,7 @@ func getWeatherForCity(_ city: City) {
 **Challenge**: Pre-load geographical boundaries for offline map functionality.
 
 <Warning>
-**Data Volume Consideration**: Cities dataset contains 150,000+ records. Consider filtering by country or region to optimize app size and performance.
+**Data Volume Consideration**: Cities dataset contains 153,000+ records. Consider filtering by country or region to optimize app size and performance.
 </Warning>
 
 <Steps>


### PR DESCRIPTION
Reconcile country/state/city counts that had drifted across pages:
- Database pages now match the GitHub Insights dump (250 / 5,299 / 153,765) with a current 'Last Updated' date
- API and marketing copy use live /stats floors (250+ / 5,000+ / 153,000+)
- Removes the 247-vs-250 and 150K-vs-151K inconsistencies and refreshes export-tool doc examples

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Claude-Session: https://claude.ai/code/session_012viasJh1XRPPBsqwYzaXMD